### PR TITLE
Notify services by default on drop in files

### DIFF
--- a/REFERENCE.md
+++ b/REFERENCE.md
@@ -1273,7 +1273,6 @@ The following parameters are available in the `systemd::service_limits` defined 
 * [`selinux_ignore_defaults`](#-systemd--service_limits--selinux_ignore_defaults)
 * [`limits`](#-systemd--service_limits--limits)
 * [`source`](#-systemd--service_limits--source)
-* [`restart_service`](#-systemd--service_limits--restart_service)
 
 ##### <a name="-systemd--service_limits--name"></a>`name`
 
@@ -1324,14 +1323,6 @@ A ``File`` resource compatible ``source``
 * Mutually exclusive with ``$limits``
 
 Default value: `undef`
-
-##### <a name="-systemd--service_limits--restart_service"></a>`restart_service`
-
-Data type: `Boolean`
-
-Restart the managed service after setting the limits
-
-Default value: `true`
 
 ### <a name="systemd--timer"></a>`systemd::timer`
 

--- a/REFERENCE.md
+++ b/REFERENCE.md
@@ -748,7 +748,7 @@ Data type: `Boolean`
 
 Notify a service for the unit, if it exists
 
-Default value: `false`
+Default value: `true`
 
 ##### <a name="-systemd--dropin_file--daemon_reload"></a>`daemon_reload`
 

--- a/manifests/dropin_file.pp
+++ b/manifests/dropin_file.pp
@@ -32,7 +32,7 @@ define systemd::dropin_file (
   String                                      $group                   = 'root',
   String                                      $mode                    = '0444',
   Boolean                                     $show_diff               = true,
-  Boolean                                     $notify_service          = false,
+  Boolean                                     $notify_service          = true,
   Boolean                                     $daemon_reload           = true,
 ) {
   include systemd

--- a/manifests/service_limits.pp
+++ b/manifests/service_limits.pp
@@ -26,16 +26,12 @@
 #
 #   * Mutually exclusive with ``$limits``
 #
-# @param restart_service
-#   Restart the managed service after setting the limits
-#
 define systemd::service_limits (
   Enum['present', 'absent', 'file'] $ensure                  = 'present',
   Stdlib::Absolutepath              $path                    = '/etc/systemd/system',
   Boolean                           $selinux_ignore_defaults = false,
   Optional[Systemd::ServiceLimits]  $limits                  = undef,
   Optional[String]                  $source                  = undef,
-  Boolean                           $restart_service         = true
 ) {
   include systemd
 
@@ -67,15 +63,6 @@ define systemd::service_limits (
     selinux_ignore_defaults => $selinux_ignore_defaults,
     content                 => $_content,
     source                  => $source,
-  }
-
-  if $restart_service {
-    exec { "restart ${name} because limits":
-      command     => "systemctl restart ${name}",
-      path        => $facts['path'],
-      refreshonly => true,
-    }
-
-    Systemd::Dropin_file["${name}-90-limits.conf"] ~> Exec["restart ${name} because limits"]
+    notify_service          => true,
   }
 }

--- a/spec/defines/service_limits_spec.rb
+++ b/spec/defines/service_limits_spec.rb
@@ -51,12 +51,21 @@ describe 'systemd::service_limits' do
               with_content(%r{IOReadBandwidthMax=/bw/max 10K})
           }
 
-          it {
-            expect(subject).to create_exec("restart #{title} because limits").with(
-              command: "systemctl restart #{title}",
-              refreshonly: true
-            )
-          }
+          describe 'with service managed' do
+            let(:pre_condition) do
+              <<-PUPPET
+              service { 'test':
+              }
+              PUPPET
+            end
+
+            it { is_expected.to compile.with_all_deps }
+
+            it do
+              is_expected.to create_file("/etc/systemd/system/#{title}.d/90-limits.conf").
+                that_notifies('Service[test]')
+            end
+          end
         end
 
         describe 'ensured absent' do
@@ -66,14 +75,7 @@ describe 'systemd::service_limits' do
 
           it do
             expect(subject).to create_file("/etc/systemd/system/#{title}.d/90-limits.conf").
-              with_ensure('absent').
-              that_notifies("Exec[restart #{title} because limits]")
-          end
-
-          it do
-            expect(subject).to create_exec("restart #{title} because limits").
-              with_command("systemctl restart #{title}").
-              with_refreshonly(true)
+              with_ensure('absent')
           end
         end
       end


### PR DESCRIPTION
This builds on 81f3eb5e7612e50726fa8450ca161bbe271419a1 which allowed services to be notified automatically. This changes it to default behavior.

Fixes #74

It's currently a draft since it includes https://github.com/camptocamp/puppet-systemd/pull/193 which I think it may depend on.