### PR TITLE
Do a daemon reload for static units

### DIFF
--- a/manifests/unit_file.pp
+++ b/manifests/unit_file.pp
@@ -104,8 +104,9 @@ define systemd::unit_file (
     } else {
       File["${path}/${name}"] ~> Service[$name]
     }
-  } elsif $ensure == 'absent' {
+  } else {
     # Work around https://tickets.puppetlabs.com/browse/PUP-9473
+    # and react to changes on static unit files (ie: .service triggered by .timer)
     exec { "${name}-systemctl-daemon-reload":
       command     => 'systemctl daemon-reload',
       refreshonly => true,


### PR DESCRIPTION
Services that are deployed by systemd::timer need to trigger a `systemctl daemon-reload` when the .service file is changed.

```puppet
systemd::timer { 'foo.timer':
    timer_content   => $foo_timer,
    service_content => $foo_service,
    active          => true,
    enable          => true,
}
```
results in a `foo.service` that is neither active nor enabled. It is a "static" unit that will be triggered by the `foo.timer` alone. This fixes voxpupuli#190 and more specifically: https://github.com/voxpupuli/puppet-systemd/issues/190#issuecomment-851701455