### PR TITLE
Dont add puppetlabs_spec_helper to Gemfile

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -23,7 +23,6 @@ group :release do
   gem 'puppet-strings', '>= 2.2',                 :require => false
 end
 
-gem 'puppetlabs_spec_helper', '~> 2.0', :require => false
 gem 'rake', :require => false
 gem 'facter', ENV['FACTER_GEM_VERSION'], :require => false, :groups => [:test]
 


### PR DESCRIPTION
voxpupuli-test already pulls it in. We can check if we really need to
add it explicitly to the Gemfile.

<!--
Thank you for contributing to this project!

- This project has a Contributor Code of Conduct: https://voxpupuli.org/coc/
- Please check that here is no existing issue or PR that addresses your problem.
- Our vulnerabilities reporting process is at https://voxpupuli.org/security/

-->
#### Pull Request (PR) description
<!--
Replace this comment with a description of your pull request.
-->

#### This Pull Request (PR) fixes the following issues
<!--
Replace this comment with the list of issues or n/a.
Use format:
Fixes #123
Fixes #124
-->
