### PR TITLE
Allow `systemd::unit_file` `Deferred` `content`

### DIFF
--- a/manifests/unit_file.pp
+++ b/manifests/unit_file.pp
@@ -1,4 +1,4 @@
-# Creates a systemd unit file
+# @summary Creates a systemd unit file
 #
 # @api public
 #
@@ -52,7 +52,7 @@
 define systemd::unit_file (
   Enum['present', 'absent', 'file']        $ensure    = 'present',
   Stdlib::Absolutepath                     $path      = '/etc/systemd/system',
-  Optional[Variant[String, Sensitive[String]]] $content = undef,
+  Optional[Variant[String, Sensitive[String], Deferred]] $content = undef,
   Optional[String]                         $source    = undef,
   Optional[Stdlib::Absolutepath]           $target    = undef,
   String                                   $owner     = 'root',


### PR DESCRIPTION
Required if you want to use this type with eg. [`node_encrypt::secret`](https://github.com/binford2k/binford2k-node_encrypt).