### PR TITLE
Add additional hash parameters for the remaining defined types

### DIFF
--- a/REFERENCE.md
+++ b/REFERENCE.md
@@ -56,6 +56,10 @@ This module allows triggering systemd commands once for all modules
 The following parameters are available in the `systemd` class:
 
 * [`service_limits`](#service_limits)
+* [`networks`](#networks)
+* [`timers`](#timers)
+* [`tmpfiles`](#tmpfiles)
+* [`unit_files`](#unit_files)
 * [`manage_resolved`](#manage_resolved)
 * [`resolved_ensure`](#resolved_ensure)
 * [`dns`](#dns)
@@ -100,6 +104,30 @@ Data type: `Hash[String,Hash[String, Any]]`
 
 May be passed a resource hash suitable for passing directly into the
 ``create_resources()`` function as called on ``systemd::service_limits``
+
+##### <a name="networks"></a>`networks`
+
+Data type: `Hash[String,Hash[String, Any]]`
+
+Hash of `systemd::network` resources
+
+##### <a name="timers"></a>`timers`
+
+Data type: `Hash[String,Hash[String, Any]]`
+
+Hash of `systemd::timer` resources
+
+##### <a name="tmpfiles"></a>`tmpfiles`
+
+Data type: `Hash[String,Hash[String, Any]]`
+
+Hash of `systemd::tmpfile` resources
+
+##### <a name="unit_files"></a>`unit_files`
+
+Data type: `Hash[String,Hash[String, Any]]`
+
+Hash of `systemd::unit_file` resources
 
 ##### <a name="manage_resolved"></a>`manage_resolved`
 
@@ -157,9 +185,10 @@ Takes a boolean argument or "allow-downgrade".
 
 ##### <a name="dnsovertls"></a>`dnsovertls`
 
-Data type: `Optional[Variant[Boolean,Enum['opportunistic', 'no']]]`
+Data type: `Optional[Variant[Boolean,Enum['yes', 'opportunistic', 'no']]]`
 
-Takes a boolean argument or "opportunistic"
+Takes a boolean argument or one of "yes", "opportunistic" or "no". "true" corresponds to
+"opportunistic" and "false" (default) to "no".
 
 ##### <a name="cache"></a>`cache`
 
@@ -275,12 +304,10 @@ The value of /etc/udev/udev.conf timeout_signal
 
 ##### <a name="udev_rules"></a>`udev_rules`
 
-Data type: `Hash`
+Data type: `Hash[String,Hash[String, Any]]`
 
 Config Hash that is used to generate instances of our
 `udev::rule` define.
-
-Default value: `{}`
 
 ##### <a name="manage_logind"></a>`manage_logind`
 
@@ -296,20 +323,16 @@ Config Hash that is used to configure settings in logind.conf
 
 ##### <a name="loginctl_users"></a>`loginctl_users`
 
-Data type: `Hash`
+Data type: `Hash[String,Hash[String, Any]]`
 
 Config Hash that is used to generate instances of our type
 `loginctl_user`.
 
-Default value: `{}`
-
 ##### <a name="dropin_files"></a>`dropin_files`
 
-Data type: `Hash`
+Data type: `Hash[String,Hash[String, Any]]`
 
 Configure dropin files via hiera with factory pattern
-
-Default value: `{}`
 
 ##### <a name="manage_all_network_files"></a>`manage_all_network_files`
 
@@ -1012,7 +1035,7 @@ Default value: `'/etc/systemd/system'`
 
 ##### <a name="content"></a>`content`
 
-Data type: `Optional[Variant[String, Sensitive[String]]]`
+Data type: `Optional[Variant[String, Sensitive[String], Deferred]]`
 
 The full content of the unit file
 

--- a/data/common.yaml
+++ b/data/common.yaml
@@ -1,5 +1,9 @@
 ---
 systemd::service_limits: {}
+systemd::networks: {}
+systemd::timers: {}
+systemd::tmpfiles: {}
+systemd::unit_files: {}
 systemd::manage_resolved: false
 systemd::resolved_ensure: 'running'
 systemd::dns: ~
@@ -34,3 +38,32 @@ systemd::manage_logind: false
 systemd::logind_settings: {}
 systemd::manage_all_network_files: false
 systemd::network_path: '/etc/systemd/network'
+systemd::loginctl_users: {}
+systemd::dropin_files: {}
+systemd::udev_rules: {}
+
+lookup_options:
+  systemd::service_limits:
+    merge:
+      strategy: deep
+  systemd::networks:
+    merge:
+      strategy: deep
+  systemd::timers:
+    merge:
+      strategy: deep
+  systemd::tmpfiles:
+    merge:
+      strategy: deep
+  systemd::unit_files:
+    merge:
+      strategy: deep
+  systemd::loginctl_users:
+    merge:
+      strategy: deep
+  systemd::dropin_files:
+    merge:
+      strategy: deep
+  systemd::udev_rules:
+    merge:
+      strategy: deep

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -6,6 +6,18 @@
 #   May be passed a resource hash suitable for passing directly into the
 #   ``create_resources()`` function as called on ``systemd::service_limits``
 #
+# @param networks
+#   Hash of `systemd::network` resources
+#
+# @param timers
+#   Hash of `systemd::timer` resources
+#
+# @param tmpfiles
+#   Hash of `systemd::tmpfile` resources
+#
+# @param unit_files
+#   Hash of `systemd::unit_file` resources
+#
 # @param manage_resolved
 #   Manage the systemd resolver
 #
@@ -120,6 +132,10 @@
 #   where all networkd files are placed in
 class systemd (
   Hash[String,Hash[String, Any]]                         $service_limits,
+  Hash[String,Hash[String, Any]]                         $networks,
+  Hash[String,Hash[String, Any]]                         $timers,
+  Hash[String,Hash[String, Any]]                         $tmpfiles,
+  Hash[String,Hash[String, Any]]                         $unit_files,
   Boolean                                                $manage_resolved,
   Enum['stopped','running']                              $resolved_ensure,
   Optional[Variant[Array[String],String]]                $dns,
@@ -154,11 +170,15 @@ class systemd (
   Systemd::LogindSettings                                $logind_settings,
   Boolean                                                $manage_all_network_files,
   Stdlib::Absolutepath                                   $network_path,
-  Hash                                                   $loginctl_users = {},
-  Hash                                                   $dropin_files = {},
-  Hash                                                   $udev_rules = {},
+  Hash[String,Hash[String, Any]]                         $loginctl_users,
+  Hash[String,Hash[String, Any]]                         $dropin_files,
+  Hash[String,Hash[String, Any]]                         $udev_rules,
 ) {
   create_resources('systemd::service_limits', $service_limits)
+  create_resources('systemd::network', $networks)
+  create_resources('systemd::timer', $timers)
+  create_resources('systemd::tmpfile', $tmpfiles)
+  create_resources('systemd::unit_file', $unit_files)
 
   if $manage_resolved and $facts['systemd_internal_services'] and $facts['systemd_internal_services']['systemd-resolved.service'] {
     contain systemd::resolved


### PR DESCRIPTION
<!--
Thank you for contributing to this project!

- This project has a Contributor Code of Conduct: https://voxpupuli.org/coc/
- Please check that here is no existing issue or PR that addresses your problem.
- Our vulnerabilities reporting process is at https://voxpupuli.org/security/

-->
#### Pull Request (PR) description
This adds parameters to manage the following resources via Hiera:
* `systemd::network`
* `systemd::timer`
* `systemd::tmpfile`
* `systemd::unit_file`

It also enables deep merging by default for all of the resource hash parameters.

#### This Pull Request (PR) fixes the following issues
N/A
