### PR TITLE
CentOS 8: Enable more accounting options

### DIFF
--- a/data/CentOS-8.yaml
+++ b/data/CentOS-8.yaml
@@ -4,3 +4,5 @@ systemd::accounting:
   DefaultBlockIOAccounting: 'yes'
   DefaultMemoryAccounting: 'yes'
   DefaultTasksAccounting: 'yes'
+  DefaultIOAccounting: 'yes'
+  DefaultIPAccounting: 'yes'

--- a/data/RedHat-8.yaml
+++ b/data/RedHat-8.yaml
@@ -4,3 +4,5 @@ systemd::accounting:
   DefaultBlockIOAccounting: 'yes'
   DefaultMemoryAccounting: 'yes'
   DefaultTasksAccounting: 'yes'
+  DefaultIOAccounting: 'yes'
+  DefaultIPAccounting: 'yes'


### PR DESCRIPTION
DefaultIOAccounting and DefaultIPAccounting are supported by CentOS 8
sowe can enable them as well.

<!--
Thank you for contributing to this project!

- This project has a Contributor Code of Conduct: https://voxpupuli.org/coc/
- Please check that here is no existing issue or PR that addresses your problem.
- Our vulnerabilities reporting process is at https://voxpupuli.org/security/

-->
#### Pull Request (PR) description
<!--
Replace this comment with a description of your pull request.
-->

#### This Pull Request (PR) fixes the following issues
<!--
Replace this comment with the list of issues or n/a.
Use format:
Fixes #123
Fixes #124
-->
