### PR TITLE
Add Debian 11 support

### DIFF
--- a/data/Debian-11.yaml
+++ b/data/Debian-11.yaml
@@ -1,0 +1,8 @@
+---
+systemd::accounting:
+  DefaultCPUAccounting: 'yes'
+  DefaultIOAccounting: 'yes'
+  DefaultIPAccounting: 'yes'
+  DefaultBlockIOAccounting: 'yes'
+  DefaultMemoryAccounting: 'yes'
+  DefaultTasksAccounting: 'yes'

--- a/metadata.json
+++ b/metadata.json
@@ -23,7 +23,8 @@
       "operatingsystemrelease": [
         "8",
         "9",
-        "10"
+        "10",
+        "11"
       ]
     },
     {


### PR DESCRIPTION
I got the data from the debian/bullseye64 Vagrant box:

```
```

<!--
Thank you for contributing to this project!

- This project has a Contributor Code of Conduct: https://voxpupuli.org/coc/
- Please check that here is no existing issue or PR that addresses your problem.
- Our vulnerabilities reporting process is at https://voxpupuli.org/security/

-->
#### Pull Request (PR) description
<!--
Replace this comment with a description of your pull request.
-->

#### This Pull Request (PR) fixes the following issues
<!--
Replace this comment with the list of issues or n/a.
Use format:
Fixes #123
Fixes #124
-->
