### PR TITLE
Use os.family for RedHat based Hiera data

### DIFF
--- a/data/CentOS-7.yaml
+++ b/data/CentOS-7.yaml
@@ -1,6 +1,0 @@
----
-systemd::accounting:
-  DefaultCPUAccounting: 'yes'
-  DefaultBlockIOAccounting: 'yes'
-  DefaultMemoryAccounting: 'yes'
-  DefaultTasksAccounting: 'yes'

--- a/data/CentOS-8.yaml
+++ b/data/CentOS-8.yaml
@@ -1,8 +1,0 @@
----
-systemd::accounting:
-  DefaultCPUAccounting: 'yes'
-  DefaultBlockIOAccounting: 'yes'
-  DefaultMemoryAccounting: 'yes'
-  DefaultTasksAccounting: 'yes'
-  DefaultIOAccounting: 'yes'
-  DefaultIPAccounting: 'yes'

--- a/data/OracleLinux-7.yaml
+++ b/data/OracleLinux-7.yaml
@@ -1,6 +1,0 @@
----
-systemd::accounting:
-  DefaultCPUAccounting: 'yes'
-  DefaultBlockIOAccounting: 'yes'
-  DefaultMemoryAccounting: 'yes'
-  DefaultTasksAccounting: 'yes'

--- a/data/OracleLinux-8.yaml
+++ b/data/OracleLinux-8.yaml
@@ -1,6 +1,0 @@
----
-systemd::accounting:
-  DefaultCPUAccounting: 'yes'
-  DefaultBlockIOAccounting: 'yes'
-  DefaultMemoryAccounting: 'yes'
-  DefaultTasksAccounting: 'yes'

--- a/hiera.yaml
+++ b/hiera.yaml
@@ -8,5 +8,7 @@ hierarchy:
     path: '%{facts.os.name}-%{facts.os.release.major}.yaml'
   - name: 'Distribution Name'
     path: '%{facts.os.name}.yaml'
+  - name: 'OS Family Major Version'
+    path: '%{facts.os.family}-%{facts.os.release.major}.yaml'
   - name: 'common'
     path: 'common.yaml'


### PR DESCRIPTION
<!--
Thank you for contributing to this project!

- This project has a Contributor Code of Conduct: https://voxpupuli.org/coc/
- Please check that here is no existing issue or PR that addresses your problem.
- Our vulnerabilities reporting process is at https://voxpupuli.org/security/

-->
#### Pull Request (PR) description
<!--
Replace this comment with a description of your pull request.
-->
Use the `os.family` fact for RedHat based systems since they will all have same defaults.  This ensures CentOS 8 replacements like Alma Linux and Rocky Linux will work without having to add additional duplicate Hiera files.  I ran into this issue with modules where I had Scientific Linux tests enabled, which is another RedHat clone.
