### PR TITLE
Add CentOS/RHEL 9 support

### DIFF
--- a/data/RedHat-9.yaml
+++ b/data/RedHat-9.yaml
@@ -1,0 +1,8 @@
+---
+systemd::accounting:
+  DefaultCPUAccounting: 'yes'
+  DefaultBlockIOAccounting: 'yes'
+  DefaultMemoryAccounting: 'yes'
+  DefaultTasksAccounting: 'yes'
+  DefaultIOAccounting: 'yes'
+  DefaultIPAccounting: 'yes'

--- a/metadata.json
+++ b/metadata.json
@@ -46,7 +46,8 @@
       "operatingsystem": "RedHat",
       "operatingsystemrelease": [
         "7",
-        "8"
+        "8",
+        "9"
       ]
     },
     {


### PR DESCRIPTION
Add CentOS/RHEL 9 support. Without this change puppet-systemd will
likely fail with the following error:

    Evaluation Error: Error while evaluating a Function Call, Class[Systemd]:
    expects a value for parameter 'accounting'
    (file: /etc/puppet/modules/systemd/manifests/service_limits.pp, line: 40, column: 3)

Tested on Centos 9 Stream.

Signed-off-by: Michele Baldessari <michele@acksyn.org>

