### PR TITLE
Declare a default for $accounting

### DIFF
--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -141,7 +141,7 @@
 #   When enabled, unused directories for dropin files will be purged
 #
 class systemd (
-  Hash[String,String]                                 $accounting,
+  Hash[String,String]                                 $accounting = {},
   Hash[String[1],Hash[String[1], Any]]                $service_limits = {},
   Hash[String[1],Hash[String[1], Any]]                $networks = {},
   Hash[String[1],Hash[String[1], Any]]                $timers = {},


### PR DESCRIPTION
In ff098e030b95fa95131bb8e65585c8bdecc23a3d the defaults were moved from data/common.yaml to init.pp but this was missed. That means on unsupported platforms it no longer works to include the class (which should be a noop).