### PR TITLE
Correct use_stub_resolver example in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -267,7 +267,7 @@ $manage_networkd is required if you want to reload it for new
 `systemd::network` resources. Setting $manage_resolved will also manage your
 `/etc/resolv.conf`.
 
-When configuring `systemd::resolved` you could set `dns_stub_resolver` to false (default) to use a *standard* `/etc/resolved.conf`, or you could set it to `true` to use the local resolver provided by `systemd-resolved`.
+When configuring `systemd::resolved` you could set `use_stub_resolver` to false (default) to use a *standard* `/etc/resolved.conf`, or you could set it to `true` to use the local resolver provided by `systemd-resolved`.
 
 Systemd has introduced `DNS Over TLS` in the release 239. Currently three states are supported `yes` (since systemd 243), `opportunistic` (true) and `no` (false, default). When enabled with `yes` or `opportunistic` `systemd-resolved` will start a TCP-session to a DNS server with `DNS Over TLS` support. When enabled with `yes` (strict mode), queries will fail if the configured DNS servers do not support `DNS Over TLS`. Note that there will be no host checking for `DNS Over TLS` due to missing implementation in `systemd-resolved`.
 


### PR DESCRIPTION
#### Pull Request (PR) description
The example in README was had used `dns_stub_resolver` when the
parameter is actually `use_stub_resolver`
