### PR TITLE
timesyncd compatibility with Debian 8

### DIFF
--- a/manifests/timesyncd.pp
+++ b/manifests/timesyncd.pp
@@ -37,10 +37,17 @@ class systemd::timesyncd (
     } else {
       $_ntp_server = join($ntp_server, ' ')
     }
+    $setting = $facts['os']['family'] ? {
+      'Debian' => $facts['os']['release']['major'] ? {
+        '8'     => 'Servers',
+        default => 'NTP',
+      },
+      default  => 'NTP',
+    }
     ini_setting { 'ntp_server':
       ensure  => 'present',
       value   => $_ntp_server,
-      setting => 'NTP',
+      setting => $setting,
       section => 'Time',
       path    => '/etc/systemd/timesyncd.conf',
       notify  => Service['systemd-timesyncd'],


### PR DESCRIPTION
#### Pull Request (PR) description
systemd has switched in version 215 from Servers= to NTP=
Debian 8 has older systemd version and needs the NTP= setting
