### PR TITLE
Add function systemd::systemd_escape

### DIFF
--- a/README.md
+++ b/README.md
@@ -425,7 +425,7 @@ or as a hash via the `systemd::loginctl_users` parameter.
 ### Systemd Escape Function
 Partially escape strings as `systemd-escape` command does.
 
-This functions only escapes a subset of chars. Non ASCII character will not escape.
+This functions only escapes a subset of chars. Non-ASCII character will not escape.
 
 ```puppet
 $result = systemd::escape('foo::bar/')

--- a/README.md
+++ b/README.md
@@ -423,7 +423,9 @@ loginctl_user { 'foo':
 or as a hash via the `systemd::loginctl_users` parameter.
 
 ### Systemd Escape Function
-Escapes strings as `systemd-escape` command does.
+Partially escape strings as `systemd-escape` command does.
+
+This functions only escapes a subset of chars. Non ASCII character will not escape.
 
 ```puppet
 $result = systemd::escape('foo::bar/')
@@ -436,6 +438,23 @@ or path escape as if with `-p` option.
 $result = systemd::escape('/mnt/foobar/', true)
 ```
 `$result` would be `mnt-foobar`.
+
+### Systemd Escape Function (uses systemd-escape)
+Escape strings by call the `systemd-escape` command in the background.
+
+It's highly recommend running the function as [deferred function](https://puppet.com/docs/puppet/6/deferring_functions.html) since it executes the command on the agent.
+
+```puppet
+$result = Deferred('systemd::systemd_escape', ["foo::bar"])
+```
+`$result` would be `foo::bar-`
+
+or path escape as if with `-p` option.
+
+```puppet
+$result = Deferred('systemd::systemd_escape', ["/mnt/foo-bar/", true])
+```
+`$result` would be `mnt-foo\x2dbar`.
 
 ## Transfer Notice
 

--- a/lib/puppet/functions/systemd/systemd_escape.rb
+++ b/lib/puppet/functions/systemd/systemd_escape.rb
@@ -10,7 +10,8 @@ Puppet::Functions.create_function(:'systemd::systemd_escape') do
     return_type 'String'
   end
 
-  def escape(input, path: false)
+  # rubocop:disable Style/OptionalBooleanParameter
+  def escape(input, path = false)
     args = []
 
     args.push('--path') if path
@@ -18,6 +19,7 @@ Puppet::Functions.create_function(:'systemd::systemd_escape') do
     args.push(input)
     exec_systemd(args)
   end
+  # rubocop:enable Style/OptionalBooleanParameter
 
   def exec_systemd(*args)
     exec_args = { failonfail: true, combine: true }

--- a/lib/puppet/functions/systemd/systemd_escape.rb
+++ b/lib/puppet/functions/systemd/systemd_escape.rb
@@ -22,7 +22,7 @@ Puppet::Functions.create_function(:'systemd::systemd_escape') do
   # rubocop:enable Style/OptionalBooleanParameter
 
   def exec_systemd(*args)
-    exec_args = { failonfail: true, combine: true }
-    Puppet::Util::Execution.execute(['systemd-escape', args], **exec_args)
+    exec_args = { failonfail: true, combine: false }
+    Puppet::Util::Execution.execute(['systemd-escape', args], **exec_args).to_s.trim
   end
 end

--- a/lib/puppet/functions/systemd/systemd_escape.rb
+++ b/lib/puppet/functions/systemd/systemd_escape.rb
@@ -1,0 +1,26 @@
+# frozen_string_literal: true
+
+# @summary Escape strings by call the `systemd-escape` command in the background.
+Puppet::Functions.create_function(:'systemd::systemd_escape') do
+  # @param input Input string
+  # @param path Use path (-p) ornon-path  style escaping.
+  dispatch :escape do
+    param 'String', :input
+    optional_param 'Optional[Boolean]', :path
+    return_type 'String'
+  end
+
+  def escape(input, path: false)
+    args = []
+
+    args.push('--path') if path
+
+    args.push(input)
+    exec_systemd(args)
+  end
+
+  def exec_systemd(*args)
+    exec_args = { failonfail: true, combine: true }
+    Puppet::Util::Execution.execute(['systemd-escape', args], **exec_args)
+  end
+end

--- a/lib/puppet/functions/systemd/systemd_escape.rb
+++ b/lib/puppet/functions/systemd/systemd_escape.rb
@@ -10,7 +10,6 @@ Puppet::Functions.create_function(:'systemd::systemd_escape') do
     return_type 'String'
   end
 
-  # rubocop:disable Style/OptionalBooleanParameter
   def escape(input, path = false)
     args = []
 
@@ -19,7 +18,6 @@ Puppet::Functions.create_function(:'systemd::systemd_escape') do
     args.push(input)
     exec_systemd(args)
   end
-  # rubocop:enable Style/OptionalBooleanParameter
 
   def exec_systemd(*args)
     exec_args = { failonfail: true, combine: false }

--- a/lib/puppet/functions/systemd/systemd_escape.rb
+++ b/lib/puppet/functions/systemd/systemd_escape.rb
@@ -23,6 +23,7 @@ Puppet::Functions.create_function(:'systemd::systemd_escape') do
 
   def exec_systemd(*args)
     exec_args = { failonfail: true, combine: false }
-    Puppet::Util::Execution.execute(['systemd-escape', args], **exec_args).to_s.trim
+    escaped = Puppet::Util::Execution.execute(['systemd-escape', args], **exec_args)
+    escaped.strip
   end
 end

--- a/spec/functions/systemd_escape_spec.rb
+++ b/spec/functions/systemd_escape_spec.rb
@@ -3,24 +3,102 @@
 require 'spec_helper'
 describe 'systemd::systemd_escape' do
   context 'with path false' do
-    it { is_expected.to run.with_params('foo', false).and_return('foo') }
-    it { is_expected.to run.with_params('foo/bar/.', false).and_return('foo-bar-.') }
-    it { is_expected.to run.with_params('/foo/bar/', false).and_return('-foo-bar-') }
-    it { is_expected.to run.with_params('//foo//bar//', false).and_return('--foo--bar--') }
-    it { is_expected.to run.with_params('//foo//bar-baz//', false).and_return('--foo--bar\x2dbaz--') }
-    it { is_expected.to run.with_params('//foo:bar,foo_bar.//', false).and_return('--foo:bar\x2cfoo_bar.--') }
-    it { is_expected.to run.with_params('.foo', false).and_return('\x2efoo') }
-    it { is_expected.to run.with_params('abcöäüß', false).and_return('abc\xc3\xb6\xc3\xa4\xc3\xbc\xc3\x9f') }
+    it do
+      allow(Puppet::Util::Execution).to receive(:execute).with(['systemd-escape', [['foo']]], { combine: false, failonfail: true }).and_return("foo\n")
+
+      is_expected.to run.with_params('foo', false).and_return('foo')
+    end
+
+    it do
+      allow(Puppet::Util::Execution).to receive(:execute).with(['systemd-escape', [['foo/bar/.']]], { combine: false, failonfail: true }).and_return("foo-bar-.\n")
+
+      is_expected.to run.with_params('foo/bar/.', false).and_return('foo-bar-.')
+    end
+
+    it do
+      allow(Puppet::Util::Execution).to receive(:execute).with(['systemd-escape', [['/foo/bar/']]], { combine: false, failonfail: true }).and_return("-foo-bar-\n")
+
+      is_expected.to run.with_params('/foo/bar/', false).and_return('-foo-bar-')
+    end
+
+    it do
+      allow(Puppet::Util::Execution).to receive(:execute).with(['systemd-escape', [['//foo//bar//']]], { combine: false, failonfail: true }).and_return("--foo--bar--\n")
+
+      is_expected.to run.with_params('//foo//bar//', false).and_return('--foo--bar--')
+    end
+
+    it do
+      allow(Puppet::Util::Execution).to receive(:execute).with(['systemd-escape', [['//foo//bar-baz//']]], { combine: false, failonfail: true }).and_return("--foo--bar\\x2dbaz--\n")
+
+      is_expected.to run.with_params('//foo//bar-baz//', false).and_return('--foo--bar\x2dbaz--')
+    end
+
+    it do
+      allow(Puppet::Util::Execution).to receive(:execute).with(['systemd-escape', [['//foo:bar,foo_bar.//']]], { combine: false, failonfail: true }).and_return("--foo:bar\\x2cfoo_bar.--\n")
+
+      is_expected.to run.with_params('//foo:bar,foo_bar.//', false).and_return('--foo:bar\x2cfoo_bar.--')
+    end
+
+    it do
+      allow(Puppet::Util::Execution).to receive(:execute).with(['systemd-escape', [['.foo']]], { combine: false, failonfail: true }).and_return("\\x2efoo\n")
+
+      is_expected.to run.with_params('.foo', false).and_return('\x2efoo')
+    end
+
+    it do
+      allow(Puppet::Util::Execution).to receive(:execute).with(['systemd-escape', [['abcöäüß']]], { combine: false, failonfail: true }).and_return("abc\\xc3\\xb6\\xc3\\xa4\\xc3\\xbc\\xc3\\x9f\n")
+
+      is_expected.to run.with_params('abcöäüß', false).and_return('abc\xc3\xb6\xc3\xa4\xc3\xbc\xc3\x9f')
+    end
   end
 
   context 'with path true' do
-    it { is_expected.to run.with_params('foo', true).and_return('foo') }
-    it { is_expected.to run.with_params('foo/bar/.', true).and_raise_error(Puppet::ExecutionFailure, %r{Execution of 'systemd-escape --path foo/bar/.' returned 1: }) }
-    it { is_expected.to run.with_params('/foo/bar/', true).and_return('foo-bar') }
-    it { is_expected.to run.with_params('//foo//bar//', true).and_return('foo-bar') }
-    it { is_expected.to run.with_params('//foo//bar-baz//', true).and_return('foo-bar\x2dbaz') }
-    it { is_expected.to run.with_params('//foo:bar,foo_bar.//', true).and_return('foo:bar\x2cfoo_bar.') }
-    it { is_expected.to run.with_params('.foo', true).and_return('\x2efoo') }
-    it { is_expected.to run.with_params('abcöäüß', true).and_return('abc\xc3\xb6\xc3\xa4\xc3\xbc\xc3\x9f') }
+    it do
+      allow(Puppet::Util::Execution).to receive(:execute).with(['systemd-escape', [%w[--path foo]]], { combine: false, failonfail: true }).and_return("foo\n")
+
+      is_expected.to run.with_params('foo', true).and_return('foo')
+    end
+
+    it do
+      allow(Puppet::Util::Execution).to receive(:execute).with(['systemd-escape', [%w[--path foo/bar/.]]], { combine: false, failonfail: true }).and_raise(Puppet::ExecutionFailure, "Execution of 'systemd-escape --path foo/bar/.' returned 1: ")
+
+      is_expected.to run.with_params('foo/bar/.', true).and_raise_error(Puppet::ExecutionFailure, %r{Execution of 'systemd-escape --path foo/bar/.' returned 1: })
+    end
+
+    it do
+      allow(Puppet::Util::Execution).to receive(:execute).with(['systemd-escape', [%w[--path /foo/bar/]]], { combine: false, failonfail: true }).and_return("foo-bar\n")
+
+      is_expected.to run.with_params('/foo/bar/', true).and_return('foo-bar')
+    end
+
+    it do
+      allow(Puppet::Util::Execution).to receive(:execute).with(['systemd-escape', [%w[--path //foo//bar//]]], { combine: false, failonfail: true }).and_return("foo-bar\n")
+
+      is_expected.to run.with_params('//foo//bar//', true).and_return('foo-bar')
+    end
+
+    it do
+      allow(Puppet::Util::Execution).to receive(:execute).with(['systemd-escape', [%w[--path //foo//bar-baz//]]], { combine: false, failonfail: true }).and_return("foo-bar\\x2dbaz\n")
+
+      is_expected.to run.with_params('//foo//bar-baz//', true).and_return('foo-bar\x2dbaz')
+    end
+
+    it do
+      allow(Puppet::Util::Execution).to receive(:execute).with(['systemd-escape', [%w[--path //foo:bar,foo_bar.//]]], { combine: false, failonfail: true }).and_return("foo:bar\\x2cfoo_bar.\n")
+
+      is_expected.to run.with_params('//foo:bar,foo_bar.//', true).and_return('foo:bar\x2cfoo_bar.')
+    end
+
+    it do
+      allow(Puppet::Util::Execution).to receive(:execute).with(['systemd-escape', [%w[--path .foo]]], { combine: false, failonfail: true }).and_return("\\x2efoo\n")
+
+      is_expected.to run.with_params('.foo', true).and_return('\x2efoo')
+    end
+
+    it do
+      allow(Puppet::Util::Execution).to receive(:execute).with(['systemd-escape', [%w[--path abcöäüß]]], { combine: false, failonfail: true }).and_return("abc\\xc3\\xb6\\xc3\\xa4\\xc3\\xbc\\xc3\\x9f\n")
+
+      is_expected.to run.with_params('abcöäüß', true).and_return('abc\xc3\xb6\xc3\xa4\xc3\xbc\xc3\x9f')
+    end
   end
 end

--- a/spec/functions/systemd_escape_spec.rb
+++ b/spec/functions/systemd_escape_spec.rb
@@ -1,0 +1,26 @@
+# frozen_string_literal: true
+
+require 'spec_helper'
+describe 'systemd::systemd_escape' do
+  context 'with path false' do
+    it { is_expected.to run.with_params('foo', false).and_return('foo') }
+    it { is_expected.to run.with_params('foo/bar/.', false).and_return('foo-bar-.') }
+    it { is_expected.to run.with_params('/foo/bar/', false).and_return('-foo-bar-') }
+    it { is_expected.to run.with_params('//foo//bar//', false).and_return('--foo--bar--') }
+    it { is_expected.to run.with_params('//foo//bar-baz//', false).and_return('--foo--bar\x2dbaz--') }
+    it { is_expected.to run.with_params('//foo:bar,foo_bar.//', false).and_return('--foo:bar\x2cfoo_bar.--') }
+    it { is_expected.to run.with_params('.foo', false).and_return('\x2efoo') }
+    it { is_expected.to run.with_params('abcöäüß', false).and_return('abc\xc3\xb6\xc3\xa4\xc3\xbc\xc3\x9f') }
+  end
+
+  context 'with path true' do
+    it { is_expected.to run.with_params('foo', true).and_return('foo') }
+    it { is_expected.to run.with_params('foo/bar/.', true).and_raise_error(%r{ path can not end}) }
+    it { is_expected.to run.with_params('/foo/bar/', true).and_return('foo-bar') }
+    it { is_expected.to run.with_params('//foo//bar//', true).and_return('foo-bar') }
+    it { is_expected.to run.with_params('//foo//bar-baz//', false).and_return('foo-bar\x2dbaz') }
+    it { is_expected.to run.with_params('//foo:bar,foo_bar.//', true).and_return('foo:bar\x2cfoo_bar.') }
+    it { is_expected.to run.with_params('.foo', true).and_return('\x2efoo') }
+    it { is_expected.to run.with_params('abcöäüß', true).and_return('abc\xc3\xb6\xc3\xa4\xc3\xbc\xc3\x9f') }
+  end
+end

--- a/spec/functions/systemd_escape_spec.rb
+++ b/spec/functions/systemd_escape_spec.rb
@@ -4,48 +4,6 @@ require 'spec_helper'
 describe 'systemd::systemd_escape' do
   context 'with path false' do
     it do
-      allow(Puppet::Util::Execution).to receive(:execute).with(['systemd-escape', [['foo']]], { combine: false, failonfail: true }).and_return("foo\n")
-
-      is_expected.to run.with_params('foo', false).and_return('foo')
-    end
-
-    it do
-      allow(Puppet::Util::Execution).to receive(:execute).with(['systemd-escape', [['foo/bar/.']]], { combine: false, failonfail: true }).and_return("foo-bar-.\n")
-
-      is_expected.to run.with_params('foo/bar/.', false).and_return('foo-bar-.')
-    end
-
-    it do
-      allow(Puppet::Util::Execution).to receive(:execute).with(['systemd-escape', [['/foo/bar/']]], { combine: false, failonfail: true }).and_return("-foo-bar-\n")
-
-      is_expected.to run.with_params('/foo/bar/', false).and_return('-foo-bar-')
-    end
-
-    it do
-      allow(Puppet::Util::Execution).to receive(:execute).with(['systemd-escape', [['//foo//bar//']]], { combine: false, failonfail: true }).and_return("--foo--bar--\n")
-
-      is_expected.to run.with_params('//foo//bar//', false).and_return('--foo--bar--')
-    end
-
-    it do
-      allow(Puppet::Util::Execution).to receive(:execute).with(['systemd-escape', [['//foo//bar-baz//']]], { combine: false, failonfail: true }).and_return("--foo--bar\\x2dbaz--\n")
-
-      is_expected.to run.with_params('//foo//bar-baz//', false).and_return('--foo--bar\x2dbaz--')
-    end
-
-    it do
-      allow(Puppet::Util::Execution).to receive(:execute).with(['systemd-escape', [['//foo:bar,foo_bar.//']]], { combine: false, failonfail: true }).and_return("--foo:bar\\x2cfoo_bar.--\n")
-
-      is_expected.to run.with_params('//foo:bar,foo_bar.//', false).and_return('--foo:bar\x2cfoo_bar.--')
-    end
-
-    it do
-      allow(Puppet::Util::Execution).to receive(:execute).with(['systemd-escape', [['.foo']]], { combine: false, failonfail: true }).and_return("\\x2efoo\n")
-
-      is_expected.to run.with_params('.foo', false).and_return('\x2efoo')
-    end
-
-    it do
       allow(Puppet::Util::Execution).to receive(:execute).with(['systemd-escape', [['abcöäüß']]], { combine: false, failonfail: true }).and_return("abc\\xc3\\xb6\\xc3\\xa4\\xc3\\xbc\\xc3\\x9f\n")
 
       is_expected.to run.with_params('abcöäüß', false).and_return('abc\xc3\xb6\xc3\xa4\xc3\xbc\xc3\x9f')
@@ -53,48 +11,6 @@ describe 'systemd::systemd_escape' do
   end
 
   context 'with path true' do
-    it do
-      allow(Puppet::Util::Execution).to receive(:execute).with(['systemd-escape', [%w[--path foo]]], { combine: false, failonfail: true }).and_return("foo\n")
-
-      is_expected.to run.with_params('foo', true).and_return('foo')
-    end
-
-    it do
-      allow(Puppet::Util::Execution).to receive(:execute).with(['systemd-escape', [%w[--path foo/bar/.]]], { combine: false, failonfail: true }).and_raise(Puppet::ExecutionFailure, "Execution of 'systemd-escape --path foo/bar/.' returned 1: ")
-
-      is_expected.to run.with_params('foo/bar/.', true).and_raise_error(Puppet::ExecutionFailure, %r{Execution of 'systemd-escape --path foo/bar/.' returned 1: })
-    end
-
-    it do
-      allow(Puppet::Util::Execution).to receive(:execute).with(['systemd-escape', [%w[--path /foo/bar/]]], { combine: false, failonfail: true }).and_return("foo-bar\n")
-
-      is_expected.to run.with_params('/foo/bar/', true).and_return('foo-bar')
-    end
-
-    it do
-      allow(Puppet::Util::Execution).to receive(:execute).with(['systemd-escape', [%w[--path //foo//bar//]]], { combine: false, failonfail: true }).and_return("foo-bar\n")
-
-      is_expected.to run.with_params('//foo//bar//', true).and_return('foo-bar')
-    end
-
-    it do
-      allow(Puppet::Util::Execution).to receive(:execute).with(['systemd-escape', [%w[--path //foo//bar-baz//]]], { combine: false, failonfail: true }).and_return("foo-bar\\x2dbaz\n")
-
-      is_expected.to run.with_params('//foo//bar-baz//', true).and_return('foo-bar\x2dbaz')
-    end
-
-    it do
-      allow(Puppet::Util::Execution).to receive(:execute).with(['systemd-escape', [%w[--path //foo:bar,foo_bar.//]]], { combine: false, failonfail: true }).and_return("foo:bar\\x2cfoo_bar.\n")
-
-      is_expected.to run.with_params('//foo:bar,foo_bar.//', true).and_return('foo:bar\x2cfoo_bar.')
-    end
-
-    it do
-      allow(Puppet::Util::Execution).to receive(:execute).with(['systemd-escape', [%w[--path .foo]]], { combine: false, failonfail: true }).and_return("\\x2efoo\n")
-
-      is_expected.to run.with_params('.foo', true).and_return('\x2efoo')
-    end
-
     it do
       allow(Puppet::Util::Execution).to receive(:execute).with(['systemd-escape', [%w[--path abcöäüß]]], { combine: false, failonfail: true }).and_return("abc\\xc3\\xb6\\xc3\\xa4\\xc3\\xbc\\xc3\\x9f\n")
 

--- a/spec/functions/systemd_escape_spec.rb
+++ b/spec/functions/systemd_escape_spec.rb
@@ -15,10 +15,10 @@ describe 'systemd::systemd_escape' do
 
   context 'with path true' do
     it { is_expected.to run.with_params('foo', true).and_return('foo') }
-    it { is_expected.to run.with_params('foo/bar/.', true).and_raise_error(%r{ path can not end}) }
+    it { is_expected.to run.with_params('foo/bar/.', true).and_raise_error(Puppet::ExecutionFailure, %r{Execution of 'systemd-escape --path foo/bar/.' returned 1: }) }
     it { is_expected.to run.with_params('/foo/bar/', true).and_return('foo-bar') }
     it { is_expected.to run.with_params('//foo//bar//', true).and_return('foo-bar') }
-    it { is_expected.to run.with_params('//foo//bar-baz//', false).and_return('foo-bar\x2dbaz') }
+    it { is_expected.to run.with_params('//foo//bar-baz//', true).and_return('foo-bar\x2dbaz') }
     it { is_expected.to run.with_params('//foo:bar,foo_bar.//', true).and_return('foo:bar\x2cfoo_bar.') }
     it { is_expected.to run.with_params('.foo', true).and_return('\x2efoo') }
     it { is_expected.to run.with_params('abcöäüß', true).and_return('abc\xc3\xb6\xc3\xa4\xc3\xbc\xc3\x9f') }


### PR DESCRIPTION
This PR is a proposal for #242 and its intended to replace the current function `systemd::escape`.


#### Pull Request (PR) description
This PR add a function `systemd::systemd_escape` based on the system call systemd-escape.

See #220 and #95

`rubocop:disable Style/OptionalBooleanParameter` is required here, otherwise puppet [wont detect](https://github.com/voxpupuli/puppet-systemd/runs/4913907935?check_suite_focus=true) the optional parameter.

#### This Pull Request (PR) fixes the following issues
<!--
Replace this comment with the list of issues or n/a.
Use format:
Fixes #123
Fixes #124
-->
Fixes #242 
