### PR TITLE
Manage entries in modules-load.d directory

### DIFF
--- a/README.md
+++ b/README.md
@@ -105,6 +105,17 @@ systemd::dropin_files:
     source: puppet:///modules/${module_name}/foo.conf
 ```
 
+### modules-load.d
+
+Create a file entry for modules-loads directory and start
+`systemd-modules-load.service`
+
+```puppet
+systemd::modules_load{'impi.conf':
+  content => "ipmi\n",
+}
+```
+
 ### tmpfiles
 
 Let this module handle file creation and systemd reloading

--- a/REFERENCE.md
+++ b/REFERENCE.md
@@ -15,6 +15,7 @@
 
 * `systemd::journald`: This class manages and configures journald.
 * `systemd::logind`: This class manages systemd's login manager configuration.
+* `systemd::modules_loads`: Activate the modules contained in modules-loads.d
 * `systemd::networkd`: This class provides an abstract way to trigger systemd-networkd
 * `systemd::resolved`: This class provides an abstract way to trigger resolved.
 * `systemd::system`: This class provides a solution to enable accounting
@@ -24,6 +25,7 @@
 ### Defined types
 
 * [`systemd::dropin_file`](#systemddropin_file): Creates a drop-in file for a systemd unit
+* [`systemd::modules_load`](#systemdmodules_load): Creates a modules-load.d drop file
 * [`systemd::network`](#systemdnetwork): Creates network config for systemd-networkd
 * [`systemd::service_limits`](#systemdservice_limits): Adds a set of custom limits to the service
 * [`systemd::timer`](#systemdtimer): Create a timer and optionally a service unit to execute with the timer unit
@@ -604,6 +606,85 @@ Data type: `Boolean`
 Notify a service for the unit, if it exists
 
 Default value: ``false``
+
+### <a name="systemdmodules_load"></a>`systemd::modules_load`
+
+Creates a modules-load.d drop file
+
+* **See also**
+  * modules-load.d(5)
+
+#### Examples
+
+##### load a module
+
+```puppet
+systemd::modules_load{'impi.conf':
+   content => "ipmi\n",
+}
+```
+
+##### override /lib/modules-load.d/myservice.conf in /etc/modules-load.d/myservice.conf
+
+```puppet
+systemd::modules_load{'myservice.conf':
+   content => "# Cancel system version of the file\n",
+}
+```
+
+#### Parameters
+
+The following parameters are available in the `systemd::modules_load` defined type:
+
+* [`filename`](#filename)
+* [`ensure`](#ensure)
+* [`path`](#path)
+* [`content`](#content)
+* [`source`](#source)
+
+##### <a name="filename"></a>`filename`
+
+Data type: `Systemd::Dropin`
+
+The name of the modules-load.d file to create
+
+Default value: `$name`
+
+##### <a name="ensure"></a>`ensure`
+
+Data type: `Enum['present', 'absent', 'file']`
+
+Whether to drop a file or remove it
+
+Default value: `'file'`
+
+##### <a name="path"></a>`path`
+
+Data type: `Stdlib::Absolutepath`
+
+The path to the main systemd modules-load.d directory
+
+Default value: `'/etc/modules-load.d'`
+
+##### <a name="content"></a>`content`
+
+Data type: `Optional[String[1]]`
+
+The literal content to write to the file
+
+* Mutually exclusive with ``$source``
+
+Default value: ``undef``
+
+##### <a name="source"></a>`source`
+
+Data type: `Optional[String[1]]`
+
+A ``File`` resource compatible ``source``
+
+* Mutually exclusive with ``$content``
+
+Default value: ``undef``
 
 ### <a name="systemdnetwork"></a>`systemd::network`
 

--- a/manifests/modules_load.pp
+++ b/manifests/modules_load.pp
@@ -1,0 +1,59 @@
+# Creates a modules-load.d drop file
+#
+# @api public
+#
+# @see modules-load.d(5)
+#
+# @param filename
+#   The name of the modules-load.d file to create
+#
+# @param ensure
+#   Whether to drop a file or remove it
+#
+# @param path
+#   The path to the main systemd modules-load.d directory
+#
+# @param content
+#   The literal content to write to the file
+#
+#   * Mutually exclusive with ``$source``
+#
+# @param source
+#   A ``File`` resource compatible ``source``
+#
+#   * Mutually exclusive with ``$content``
+#
+# @example load a module
+#   systemd::modules_load{'impi.conf':
+#      content => "ipmi\n",
+#   }
+#
+# @example override /lib/modules-load.d/myservice.conf in /etc/modules-load.d/myservice.conf
+#   systemd::modules_load{'myservice.conf':
+#      content => "# Cancel system version of the file\n",
+#   }
+#
+define systemd::modules_load (
+  Enum['present', 'absent', 'file'] $ensure   = 'file',
+  Systemd::Dropin                   $filename = $name,
+  Stdlib::Absolutepath              $path     = '/etc/modules-load.d',
+  Optional[String[1]]               $content  = undef,
+  Optional[String[1]]               $source   = undef,
+) {
+  include systemd::modules_loads
+
+  $_tmp_file_ensure = $ensure ? {
+    'present' => 'file',
+    default   => $ensure,
+  }
+
+  file { "${path}/${filename}":
+    ensure  => $_tmp_file_ensure,
+    content => $content,
+    source  => $source,
+    owner   => 'root',
+    group   => 'root',
+    mode    => '0444',
+    notify  => Class['systemd::modules_loads'],
+  }
+}

--- a/manifests/modules_loads.pp
+++ b/manifests/modules_loads.pp
@@ -1,0 +1,13 @@
+# Activate the modules contained in modules-loads.d
+#
+# @api private
+#
+# @see systemd-modules-load.service(8)
+#
+class systemd::modules_loads {
+  exec { 'systemd-modules-load' :
+    command     => 'systemctl start systemd-modules-load.service',
+    refreshonly => true,
+    path        => $facts['path'],
+  }
+}

--- a/spec/defines/modules_load_spec.rb
+++ b/spec/defines/modules_load_spec.rb
@@ -4,9 +4,9 @@ require 'spec_helper'
 
 describe 'systemd::modules_load' do
   context 'supported operating systems' do
-    on_supported_os.each do |os, facts|
+    on_supported_os.each do |os, os_facts|
       context "on #{os}" do
-        let(:facts) { facts }
+        let(:facts) { os_facts }
         let(:title) { 'random_module.conf' }
         let(:params) { { content: 'random stuff' } }
 

--- a/spec/defines/modules_load_spec.rb
+++ b/spec/defines/modules_load_spec.rb
@@ -1,0 +1,41 @@
+# frozen_string_literal: true
+
+require 'spec_helper'
+
+describe 'systemd::modules_load' do
+  context 'supported operating systems' do
+    on_supported_os.each do |os, facts|
+      context "on #{os}" do
+        let(:facts) { facts }
+        let(:title) { 'random_module.conf' }
+        let(:params) { { content: 'random stuff' } }
+
+        it { is_expected.to compile.with_all_deps }
+        it { is_expected.to contain_systemd__modules_load('random_module.conf') }
+
+        it { is_expected.to contain_file('/etc/modules-load.d/random_module.conf') }
+
+        it {
+          is_expected.to contain_file('/etc/modules-load.d/random_module.conf').with
+
+          {
+            ensure: 'file',
+            content: 'random stuff',
+            mode: '0444'
+          }
+        }
+
+        it { is_expected.to contain_class('systemd::modules_loads') }
+        it { is_expected.to contain_exec('systemd-modules-load').with_command('systemctl start systemd-modules-load.service') }
+
+        context 'with a bad modules-load name' do
+          let(:title) { 'test.badtype' }
+
+          it {
+            is_expected.to compile.and_raise_error(%r{expects a match for Systemd::Dropin})
+          }
+        end
+      end
+    end
+  end
+end


### PR DESCRIPTION
#### Pull Request (PR) description

A new type `systemd::modules_load` can add entries
to the directory `/etc/modules-load.d`.

```puppet
systemd::modules_load{'ipmi.conf':
  content => "ipmi\n",
}
```
Upon modification `systemctl  start systemd-modules-load.service` will
be called to activate the new file.


