### PR TITLE
systemd::escape: Also escape - (dash)

### DIFF
--- a/functions/escape.pp
+++ b/functions/escape.pp
@@ -34,6 +34,7 @@ function systemd::escape(String[1] $input, Boolean $path = false) >> String {
       }
       '/': { $_escaped = '-' }
       ',': { $_escaped = '\x2c' }
+      '-': { $_escaped = '\x2d' }
       default: { $_escaped = $_token }
     }
     $_escaped

--- a/spec/functions/escape_spec.rb
+++ b/spec/functions/escape_spec.rb
@@ -9,6 +9,7 @@ describe 'systemd::escape' do
     it { is_expected.to run.with_params('//foo//bar//', false).and_return('--foo--bar--') }
     it { is_expected.to run.with_params('//foo:bar,foo_bar.//', false).and_return('--foo:bar\x2cfoo_bar.--') }
     it { is_expected.to run.with_params('.foo', false).and_return('\x2efoo') }
+    it { is_expected.to run.with_params('/foo/bar-baz/qux-quux', false).and_return('-foo-bar\x2dbaz-qux\x2dquux') }
   end
 
   context 'with path true' do
@@ -18,5 +19,6 @@ describe 'systemd::escape' do
     it { is_expected.to run.with_params('//foo//bar//', true).and_return('foo-bar') }
     it { is_expected.to run.with_params('//foo:bar,foo_bar.//', true).and_return('foo:bar\x2cfoo_bar.') }
     it { is_expected.to run.with_params('.foo', true).and_return('\x2efoo') }
+    it { is_expected.to run.with_params('/foo/bar-baz/qux-quux', true).and_return('foo-bar\x2dbaz-qux\x2dquux') }
   end
 end


### PR DESCRIPTION
We also need to escape dashes in unit names, for instance for .swap services on device nodes with dashes in them.

systemd-escape escapes dashes:
```
# systemd-escape -p /dev/disk/by-id/scsi-0QEMU_QEMU_HARDDISK_drive-ua-swap
dev-disk-by\x2did-scsi\x2d0QEMU_QEMU_HARDDISK_drive\x2dua\x2dswap
```
but this function does not (yet).

In the long term, we may want to more closely match the behaviour of
systemd's unit-name.c, but this is all I need for now.

#### Pull Request (PR) description
Fix systemd::escape a bit