### PR TITLE
Install systemd-resolved on CentOS 8 and 9

### DIFF
--- a/README.md
+++ b/README.md
@@ -292,6 +292,9 @@ class{'systemd':
 }
 ```
 
+when `manage_systemd` is true any required sub package, e.g. `systemd-resolved` on CentOS 8, will be installed. However configuration of
+systemd-resolved will only occur on second puppet run after that installation.
+
 This requires [puppetlabs-inifile](https://forge.puppet.com/puppetlabs/inifile), which is only a soft dependency in this module (you need to explicitly install it). Both parameters accept a string or an array.
 
 ### Resource Accounting

--- a/REFERENCE.md
+++ b/REFERENCE.md
@@ -13,6 +13,7 @@
 
 #### Private Classes
 
+* `systemd::install`: Install any systemd sub packages
 * `systemd::journald`: This class manages and configures journald.
 * `systemd::logind`: This class manages systemd's login manager configuration.
 * `systemd::modules_loads`: Activate the modules contained in modules-loads.d
@@ -68,6 +69,7 @@ The following parameters are available in the `systemd` class:
 * [`unit_files`](#unit_files)
 * [`manage_resolved`](#manage_resolved)
 * [`resolved_ensure`](#resolved_ensure)
+* [`resolved_package`](#resolved_package)
 * [`dns`](#dns)
 * [`fallback_dns`](#fallback_dns)
 * [`domains`](#domains)
@@ -160,6 +162,14 @@ Data type: `Enum['stopped','running']`
 The state that the ``resolved`` service should be in
 
 Default value: `'running'`
+
+##### <a name="resolved_package"></a>`resolved_package`
+
+Data type: `Optional[Enum['systemd-resolved']]`
+
+The name of a systemd sub package needed for systemd-resolved if one needs to be installed.
+
+Default value: ``undef``
 
 ##### <a name="dns"></a>`dns`
 

--- a/data/RedHat-8.yaml
+++ b/data/RedHat-8.yaml
@@ -1,4 +1,6 @@
 ---
+systemd::resolved_package: 'systemd-resolved'
+
 systemd::accounting:
   DefaultCPUAccounting: 'yes'
   DefaultBlockIOAccounting: 'yes'

--- a/data/RedHat-9.yaml
+++ b/data/RedHat-9.yaml
@@ -1,4 +1,6 @@
 ---
+systemd::resolved_package: 'systemd-resolved'
+
 systemd::accounting:
   DefaultCPUAccounting: 'yes'
   DefaultBlockIOAccounting: 'yes'

--- a/manifests/install.pp
+++ b/manifests/install.pp
@@ -1,0 +1,10 @@
+# @summary Install any systemd sub packages
+# @api private
+#
+class systemd::install {
+  if $systemd::manage_resolved and $systemd::resolved_package {
+    package { $systemd::resolved_package:
+      ensure => present,
+    }
+  }
+}

--- a/spec/classes/init_spec.rb
+++ b/spec/classes/init_spec.rb
@@ -16,6 +16,7 @@ describe 'systemd' do
         it { is_expected.not_to create_service('systemd-resolved') }
         it { is_expected.not_to create_service('systemd-networkd') }
         it { is_expected.not_to create_service('systemd-timesyncd') }
+        it { is_expected.not_to contain_package('systemd-resolved') }
 
         context 'when enabling resolved and networkd' do
           let(:params) do
@@ -30,6 +31,13 @@ describe 'systemd' do
           it { is_expected.to create_service('systemd-networkd').with_ensure('running') }
           it { is_expected.to create_service('systemd-networkd').with_enable(true) }
           it { is_expected.not_to contain_file('/etc/systemd/network') }
+
+          case [facts[:os]['family'], facts[:os]['release']['major']]
+          when %w[RedHat 8], %w[RedHat 9]
+            it { is_expected.to contain_package('systemd-resolved') }
+          else
+            it { is_expected.not_to contain_package('systemd-resolved') }
+          end
         end
 
         context 'when enabling resolved with DNS values (string)' do


### PR DESCRIPTION
#### Pull Request (PR) description

On CentOS 8 and 9 systemd-resolved must be installed to use
systemd-resolved.

Install the package if `manage_resolved` is `true` which is not the default.

Since the `systemd_internal_services` fact will only be populated
once the package is installed a second puppet run will be required
to actually configure systemd-resolved.
