### PR TITLE
unit_file: Implement selinux_ignore_defaults

### DIFF
--- a/REFERENCE.md
+++ b/REFERENCE.md
@@ -1169,7 +1169,8 @@ The following parameters are available in the `systemd::unit_file` defined type:
 * [`active`](#active)
 * [`restart`](#restart)
 * [`hasrestart`](#hasrestart)
-* [`hastatus`](#hastatus)
+* [`hasstatus`](#hasstatus)
+* [`selinux_ignore_defaults`](#selinux_ignore_defaults)
 
 ##### <a name="name"></a>`name`
 
@@ -1287,13 +1288,21 @@ maps to the same param on the service resource. Optional in the module because i
 
 Default value: ``undef``
 
-##### <a name="hastatus"></a>`hastatus`
+##### <a name="hasstatus"></a>`hasstatus`
 
 Data type: `Boolean`
 
 maps to the same param on the service resource. true in the module because it's true in the service resource type
 
 Default value: ``true``
+
+##### <a name="selinux_ignore_defaults"></a>`selinux_ignore_defaults`
+
+Data type: `Boolean`
+
+maps to the same param on the file resource for the unit. false in the module because it's false in the file resource type
+
+Default value: ``false``
 
 ## Resource types
 

--- a/manifests/unit_file.pp
+++ b/manifests/unit_file.pp
@@ -55,6 +55,9 @@
 # @param hasstatus
 #   maps to the same param on the service resource. true in the module because it's true in the service resource type
 #
+# @param selinux_ignore_defaults
+#   maps to the same param on the file resource for the unit. false in the module because it's false in the file resource type
+#
 define systemd::unit_file (
   Enum['present', 'absent', 'file']        $ensure    = 'present',
   Stdlib::Absolutepath                     $path      = '/etc/systemd/system',
@@ -70,6 +73,7 @@ define systemd::unit_file (
   Optional[String]                         $restart   = undef,
   Optional[Boolean]                        $hasrestart = undef,
   Boolean                                  $hasstatus = true,
+  Boolean                                  $selinux_ignore_defaults = false,
 ) {
   include systemd
 
@@ -91,14 +95,15 @@ define systemd::unit_file (
   }
 
   file { "${path}/${name}":
-    ensure    => $_ensure,
-    content   => $content,
-    source    => $source,
-    target    => $_target,
-    owner     => $owner,
-    group     => $group,
-    mode      => $mode,
-    show_diff => $show_diff,
+    ensure                  => $_ensure,
+    content                 => $content,
+    source                  => $source,
+    target                  => $_target,
+    owner                   => $owner,
+    group                   => $group,
+    mode                    => $mode,
+    show_diff               => $show_diff,
+    selinux_ignore_defaults => $selinux_ignore_defaults,
   }
 
   if $enable != undef or $active != undef {

--- a/spec/defines/unit_file_spec.rb
+++ b/spec/defines/unit_file_spec.rb
@@ -12,6 +12,31 @@ describe 'systemd::unit_file' do
 
         it { is_expected.to compile.with_all_deps }
 
+        context 'with defaults' do
+          it do
+            expect(subject).to contain_file("/etc/systemd/system/#{title}").
+              with_selinux_ignore_defaults(false)
+          end
+        end
+
+        context 'selinux_ignore_defaults => false' do
+          let(:params) { { selinux_ignore_defaults: false } }
+
+          it do
+            expect(subject).to contain_file("/etc/systemd/system/#{title}").
+              with_selinux_ignore_defaults(false)
+          end
+        end
+
+        context 'selinux_ignore_defaults => true' do
+          let(:params) { { selinux_ignore_defaults: true } }
+
+          it do
+            expect(subject).to contain_file("/etc/systemd/system/#{title}").
+              with_selinux_ignore_defaults(true)
+          end
+        end
+
         context 'with non-sensitive Content' do
           let(:params) { { content: 'non-sensitive Content' } }
 


### PR DESCRIPTION
The parameter comes from the file resource type:
* https://puppet.com/docs/puppet/7/types/file.html#file-attribute-selinux_ignore_defaults.
With the new parameter in this defined resource we can configure the same param for the underlying file resource for the systemd unit.

Upstream docs:
* https://github.com/puppetlabs/puppet/blob/053ee58b62abd2063d6b05a077a7b6991769b9bd/lib/puppet/type/file/selcontext.rb#L85-L94
* https://github.com/puppetlabs/puppet/commit/ac2262d071cc2c9841843354585980696c689ca3
