### PR TITLE
Manage systemd-coredump config and setup

### DIFF
--- a/README.md
+++ b/README.md
@@ -260,7 +260,8 @@ systemd::network{'eth0.network':
 ### Services
 
 Systemd provides multiple services. Currently you can manage `systemd-resolved`,
-`systemd-timesyncd`, `systemd-networkd`, `systemd-journald` and `systemd-logind`
+`systemd-timesyncd`, `systemd-networkd`, `systemd-journald`, `systemd-coredump`
+and `systemd-logind`
 via the main class:
 
 ```puppet
@@ -271,6 +272,7 @@ class{'systemd':
   manage_journald  => true,
   manage_udevd     => true,
   manage_logind    => true,
+  manage_coredump  => true,
 }
 ```
 
@@ -360,6 +362,25 @@ systemd::udev::rule:
   rules:
     - 'ACTION=="add", KERNEL=="sda", RUN+="/bin/raw /dev/raw/raw1 %N"'
     - 'ACTION=="add", KERNEL=="sdb", RUN+="/bin/raw /dev/raw/raw2 %N"',
+```
+
+### coredump configuration
+The `systemd-coredump `system can be configured.
+
+```puppet
+class{'systemd':
+  manage_coredump    => true,
+  coredump_backtrace => true,
+  coredump_settings  => {
+    'Storage'         => 'external',
+    'Compress'        => 'yes',
+    'ProcessSizeMax'  => '2G',
+    'ExternalSizeMax' => '10G',
+    'JournalSizeMax'  => '20T',
+    'MaxUse'          => '1E',
+    "MaxFree'         => '1P',
+  }
+}
 ```
 
 ### logind configuration

--- a/REFERENCE.md
+++ b/REFERENCE.md
@@ -13,6 +13,7 @@
 
 #### Private Classes
 
+* `systemd::coredump`: This class manages the systemd-coredump configuration.
 * `systemd::install`: Install any systemd sub packages
 * `systemd::journald`: This class manages and configures journald.
 * `systemd::logind`: This class manages systemd's login manager configuration.
@@ -44,6 +45,7 @@
 
 ### Data types
 
+* [`Systemd::CoredumpSettings`](#systemdcoredumpsettings): Configurations for coredump.conf
 * [`Systemd::Dropin`](#systemddropin): custom datatype that validates filenames/paths for valid systemd dropin files
 * [`Systemd::JournaldSettings`](#systemdjournaldsettings): Matches Systemd journald config Struct
 * [`Systemd::JournaldSettings::Ensure`](#systemdjournaldsettingsensure): defines allowed ensure states for systemd-journald settings
@@ -105,6 +107,9 @@ The following parameters are available in the `systemd` class:
 * [`manage_accounting`](#manage_accounting)
 * [`accounting`](#accounting)
 * [`purge_dropin_dirs`](#purge_dropin_dirs)
+* [`manage_coredump`](#manage_coredump)
+* [`coredump_settings`](#coredump_settings)
+* [`coredump_backtrace`](#coredump_backtrace)
 
 ##### <a name="service_limits"></a>`service_limits`
 
@@ -463,6 +468,30 @@ Data type: `Boolean`
 When enabled, unused directories for dropin files will be purged
 
 Default value: ``true``
+
+##### <a name="manage_coredump"></a>`manage_coredump`
+
+Data type: `Boolean`
+
+Should systemd-coredump configuration be managed
+
+Default value: ``false``
+
+##### <a name="coredump_settings"></a>`coredump_settings`
+
+Data type: `Systemd::CoredumpSettings`
+
+Hash of systemd-coredump configurations for coredump.conf
+
+Default value: `{}`
+
+##### <a name="coredump_backtrace"></a>`coredump_backtrace`
+
+Data type: `Boolean`
+
+Add --backtrace to systemd-coredump call in the kernel.core_pattern setting.
+
+Default value: ``false``
 
 ### <a name="systemdtmpfiles"></a>`systemd::tmpfiles`
 
@@ -1407,6 +1436,27 @@ Data type: `Boolean`
 Use path (-p) ornon-path  style escaping.
 
 ## Data types
+
+### <a name="systemdcoredumpsettings"></a>`Systemd::CoredumpSettings`
+
+Configurations for coredump.conf
+
+* **See also**
+  * https://www.freedesktop.org/software/systemd/man/coredump.conf.html
+
+Alias of
+
+```puppet
+Struct[{
+    Optional['Storage']         => Enum['none', 'external', 'journal'],
+    Optional['Compress']        => Enum['yes','no'],
+    Optional['ProcessSizeMax']  => Pattern[/^[0-9]+(K|M|G|T|P|E)?$/],
+    Optional['ExternalSizeMax'] => Pattern[/^[0-9]+(K|M|G|T|P|E)?$/],
+    Optional['JournalSizeMax']  => Pattern[/^[0-9]+(K|M|G|T|P|E)?$/],
+    Optional['MaxUse']          => Pattern[/^[0-9]+(K|M|G|T|P|E)?$/],
+    Optional['MaxFree']         => Pattern[/^[0-9]+(K|M|G|T|P|E)?$/],
+  }]
+```
 
 ### <a name="systemddropin"></a>`Systemd::Dropin`
 

--- a/manifests/coredump.pp
+++ b/manifests/coredump.pp
@@ -1,0 +1,22 @@
+# @api private
+# @summary This class manages the systemd-coredump configuration.
+# @see https://www.freedesktop.org/software/systemd/man/systemd-coredump.html
+class systemd::coredump {
+  assert_private()
+
+  $systemd::coredump_settings.each |$option, $value| {
+    ini_setting {
+      "coredump_${option}":
+        path    => '/etc/systemd/coredump.conf',
+        section => 'Coredump',
+        setting => $option,
+        value   => $value,
+    }
+  }
+
+  systemd::dropin_file { 'coredump_backtrace.conf':
+    ensure  => bool2str($systemd::coredump_backtrace, 'file', 'absent'),
+    unit    => 'systemd-coredump@.service',
+    content => "# Puppet\n[Service]\nExecStart=\nExecStart=-/usr/lib/systemd/systemd-coredump --backtrace\n",
+  }
+}

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -143,6 +143,15 @@
 # @param purge_dropin_dirs
 #   When enabled, unused directories for dropin files will be purged
 #
+# @param manage_coredump
+#   Should systemd-coredump configuration be managed
+#
+# @param coredump_settings
+#   Hash of systemd-coredump configurations for coredump.conf
+#
+# @param coredump_backtrace
+#   Add --backtrace to systemd-coredump call systemd-coredump@.service unit
+#
 class systemd (
   Hash[String,String]                                 $accounting = {},
   Hash[String[1],Hash[String[1], Any]]                $service_limits = {},
@@ -187,6 +196,9 @@ class systemd (
   Hash                                                $loginctl_users = {},
   Hash                                                $dropin_files = {},
   Hash                                                $udev_rules = {},
+  Boolean                                             $manage_coredump = false,
+  Systemd::CoredumpSettings                           $coredump_settings = {},
+  Boolean                                             $coredump_backtrace = false,
 ) {
   contain systemd::install
 
@@ -243,6 +255,10 @@ class systemd (
 
   if $manage_logind {
     contain systemd::logind
+  }
+
+  if $manage_coredump {
+    contain systemd::coredump
   }
 
   $dropin_files.each |$name, $resource| {

--- a/spec/type_aliases/systemd_coredumpsettings_spec.rb
+++ b/spec/type_aliases/systemd_coredumpsettings_spec.rb
@@ -1,0 +1,42 @@
+# frozen_string_literal: true
+
+require 'spec_helper'
+
+describe 'Systemd::CoredumpSettings' do
+  it { is_expected.to allow_value({ 'Storage' => 'none' }) }
+
+  it {
+    is_expected.to allow_value(
+      {
+        'Storage' => 'external',
+        'Compress' => 'yes',
+        'ProcessSizeMax' => '123K',
+        'ExternalSizeMax' => '456G',
+        'JournalSizeMax' => '45T',
+        'MaxUse' => '1P',
+        'MaxFree' => '1E',
+      }
+    )
+  }
+
+  it {
+    is_expected.to allow_value(
+      {
+        'Storage' => 'journal',
+        'Compress' => 'no',
+        'ProcessSizeMax' => '123',
+        'ExternalSizeMax' => '456',
+        'JournalSizeMax' => '45',
+        'MaxUse' => '1',
+        'MaxFree' => '5',
+      }
+    )
+  }
+
+  it { is_expected.not_to allow_value({ 'Storage' => 'big' }) }
+  it { is_expected.not_to allow_value({ 'Compress' => 'maybe' }) }
+  it { is_expected.not_to allow_value({ 'MaxUse' => '-10' }) }
+  it { is_expected.not_to allow_value({ 'MaxFee' => '10Gig' }) }
+  it { is_expected.not_to allow_value({ 'ProcessSizeMax' => '20g' }) }
+  it { is_expected.not_to allow_value({ 'JournalSizeMax' => '20Z' }) }
+end

--- a/types/coredumpsettings.pp
+++ b/types/coredumpsettings.pp
@@ -1,0 +1,14 @@
+# @summary Configurations for coredump.conf
+# @see https://www.freedesktop.org/software/systemd/man/coredump.conf.html
+#
+type Systemd::CoredumpSettings = Struct[
+  {
+    Optional['Storage']         => Enum['none', 'external', 'journal'],
+    Optional['Compress']        => Enum['yes','no'],
+    Optional['ProcessSizeMax']  => Pattern[/^[0-9]+(K|M|G|T|P|E)?$/],
+    Optional['ExternalSizeMax'] => Pattern[/^[0-9]+(K|M|G|T|P|E)?$/],
+    Optional['JournalSizeMax']  => Pattern[/^[0-9]+(K|M|G|T|P|E)?$/],
+    Optional['MaxUse']          => Pattern[/^[0-9]+(K|M|G|T|P|E)?$/],
+    Optional['MaxFree']         => Pattern[/^[0-9]+(K|M|G|T|P|E)?$/],
+  }
+]


### PR DESCRIPTION
#### Pull Request (PR) description

Manage the systemd-coredump configuration.

* `systemd::manage_coredump` to enable everything
* `systemd::coredump_settings` will manage `/etc/systemd/coredump.conf`
* `systemd::backtrace` if true will add `--backtrace` to the `systemd-coredump` call.


So typical use would be

```puppet
class{'systemd':
  manage_coredump   => true,
  coredump_settings => {
    'Storage' => 'external',
  },
  coredump_backtrace => true,
}
```

to enable storing cores on disk and writing backtraces to
the journal.

