### PR TITLE
Don't manage /etc/resolv.conf if systemd-resolved is stopped

### DIFF
--- a/README.md
+++ b/README.md
@@ -284,6 +284,18 @@ When configuring `systemd::resolved` you could set `use_stub_resolver` to false 
 
 Systemd has introduced `DNS Over TLS` in the release 239. Currently three states are supported `yes` (since systemd 243), `opportunistic` (true) and `no` (false, default). When enabled with `yes` or `opportunistic` `systemd-resolved` will start a TCP-session to a DNS server with `DNS Over TLS` support. When enabled with `yes` (strict mode), queries will fail if the configured DNS servers do not support `DNS Over TLS`. Note that there will be no host checking for `DNS Over TLS` due to missing implementation in `systemd-resolved`.
 
+Stopping `systemd-resolved` once running can be problematic and care should be taken.
+
+```puppet
+class{'systemd':
+  manage_resolved => true,
+  resolved_ensure => false,
+}
+```
+
+will stop the service and should also copy `/run/systemd/resolve/resolv.conf` to `/etc/resolve.conf`.
+* Writing your own file to `/etc/resolv.conf` is also possible.
+
 It is possible to configure the default ntp servers in `/etc/systemd/timesyncd.conf`:
 
 ```puppet
@@ -298,6 +310,8 @@ when `manage_systemd` is true any required sub package, e.g. `systemd-resolved` 
 systemd-resolved will only occur on second puppet run after that installation.
 
 This requires [puppetlabs-inifile](https://forge.puppet.com/puppetlabs/inifile), which is only a soft dependency in this module (you need to explicitly install it). Both parameters accept a string or an array.
+
+
 
 ### Resource Accounting
 

--- a/REFERENCE.md
+++ b/REFERENCE.md
@@ -165,7 +165,9 @@ Default value: ``false``
 
 Data type: `Enum['stopped','running']`
 
-The state that the ``resolved`` service should be in
+The state that the ``resolved`` service should be in. When migrating from 'running' to
+'stopped' an attempt will be made to restore a working `/etc/resolv.conf` using
+`/run/systemd/resolved/resolv.conf`.
 
 Default value: `'running'`
 
@@ -270,6 +272,7 @@ Data type: `Boolean`
 
 Takes a boolean argument. When "false" (default) it uses /run/systemd/resolve/resolv.conf
 as /etc/resolv.conf. When "true", it uses /run/systemd/resolve/stub-resolv.conf
+When `resolved_ensure` is `stopped` this parameter is ignored.
 
 Default value: ``false``
 

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -22,7 +22,9 @@
 #   Manage the systemd resolver
 #
 # @param resolved_ensure
-#   The state that the ``resolved`` service should be in
+#   The state that the ``resolved`` service should be in. When migrating from 'running' to
+#   'stopped' an attempt will be made to restore a working `/etc/resolv.conf` using
+#   `/run/systemd/resolved/resolv.conf`.
 #
 # @param resolved_package
 #   The name of a systemd sub package needed for systemd-resolved if one needs to be installed.
@@ -67,6 +69,8 @@
 # @param use_stub_resolver
 #   Takes a boolean argument. When "false" (default) it uses /run/systemd/resolve/resolv.conf
 #   as /etc/resolv.conf. When "true", it uses /run/systemd/resolve/stub-resolv.conf
+#   When `resolved_ensure` is `stopped` this parameter is ignored.
+#
 # @param manage_networkd
 #   Manage the systemd network daemon
 #

--- a/spec/acceptance/resolved_spec.rb
+++ b/spec/acceptance/resolved_spec.rb
@@ -2,7 +2,7 @@
 
 require 'spec_helper_acceptance'
 
-describe 'systemd' do
+describe 'systemd with manage_resolved true' do
   context 'configure systemd resolved' do
     it 'works idempotently with no errors' do
       pp = <<-PUPPET
@@ -21,6 +21,27 @@ describe 'systemd' do
     describe service('systemd-resolved'), unless: (fact('os.release.major') == '7' and fact('os.family') == 'RedHat') do
       it { is_expected.to be_running }
       it { is_expected.to be_enabled }
+    end
+  end
+
+  context 'configure systemd stopped' do
+    it 'works idempotently with no errors' do
+      pp = <<-PUPPET
+      class{'systemd':
+        manage_resolved    => true,
+        resolved_ensure    => 'stopped',
+        manage_resolv_conf => #{default[:hypervisor] != 'docker'},
+      }
+      PUPPET
+      apply_manifest(pp, catch_failures: true)
+      # RedHat 9 and newer installs package first run before fact  $facts['internal_services'] is set
+      apply_manifest(pp, catch_failures: true) if Gem::Version.new(fact('os.release.major')) >= Gem::Version.new('9') && (fact('os.family') == 'RedHat')
+      apply_manifest(pp, catch_changes: true)
+    end
+
+    describe service('systemd-resolved') do
+      it { is_expected.not_to be_running }
+      it { is_expected.not_to be_enabled }
     end
   end
 end


### PR DESCRIPTION
#### Pull Request (PR) description

If `systemd-resolved` is stopped but managed via

```
class{'systemd:
  managed_resolved => true,
  resolved_ensure  => 'stopped',
}
```
Then the files in `/var/run/systemd/resolv` will either
be stale(just stopped) or missing(after reboot). In both cases it
makes no sense to manage `/etc/resolv.conf`.

More over for the case where `systemd-resolved` has just
been stopped reinstate `/etc/resolv.conf` as `/run/systemd/resolve/resolv.conf`.

#### This Pull Request (PR) fixes the following issues
Fixes #203
