### PR TITLE
Do not install  systemd-resolved RedHat 8

### DIFF
--- a/data/RedHat-8.yaml
+++ b/data/RedHat-8.yaml
@@ -1,6 +1,4 @@
 ---
-systemd::resolved_package: 'systemd-resolved'
-
 systemd::accounting:
   DefaultCPUAccounting: 'yes'
   DefaultBlockIOAccounting: 'yes'

--- a/spec/classes/init_spec.rb
+++ b/spec/classes/init_spec.rb
@@ -34,7 +34,7 @@ describe 'systemd' do
           it { is_expected.not_to contain_file('/etc/systemd/network') }
 
           case [facts[:os]['family'], facts[:os]['release']['major']]
-          when %w[RedHat 8], %w[RedHat 9]
+          when %w[RedHat 9]
             it { is_expected.to contain_package('systemd-resolved') }
           else
             it { is_expected.not_to contain_package('systemd-resolved') }


### PR DESCRIPTION
#### Pull Request (PR) description

MR #246 started installing the `systemd-resolved` package
on RedHat 8 and 9 however this quite wrong for 8 where
systemd-resolved is not a sub package.

```
> rpm -qf /usr/bin/systemd-resolve
systemd-239-56.el8.x86_64
```
