### PR TITLE
New parmater manage_resolv_conf for /etc/resolv.conf

### DIFF
--- a/REFERENCE.md
+++ b/REFERENCE.md
@@ -81,6 +81,7 @@ The following parameters are available in the `systemd` class:
 * [`dnsovertls`](#dnsovertls)
 * [`cache`](#cache)
 * [`dns_stub_listener`](#dns_stub_listener)
+* [`manage_resolv_conf`](#manage_resolv_conf)
 * [`use_stub_resolver`](#use_stub_resolver)
 * [`manage_networkd`](#manage_networkd)
 * [`networkd_ensure`](#networkd_ensure)
@@ -254,6 +255,14 @@ Data type: `Optional[Variant[Boolean,Enum['udp','tcp']]]`
 Takes a boolean argument or one of "udp" and "tcp".
 
 Default value: ``undef``
+
+##### <a name="manage_resolv_conf"></a>`manage_resolv_conf`
+
+Data type: `Boolean`
+
+For when `manage_resolved` is `true` should the file `/etc/resolv.conf` be managed.
+
+Default value: ``true``
 
 ##### <a name="use_stub_resolver"></a>`use_stub_resolver`
 
@@ -489,7 +498,7 @@ Default value: `{}`
 
 Data type: `Boolean`
 
-Add --backtrace to systemd-coredump call in the kernel.core_pattern setting.
+Add --backtrace to systemd-coredump call systemd-coredump@.service unit
 
 Default value: ``false``
 

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -61,6 +61,9 @@
 # @param dns_stub_listener
 #   Takes a boolean argument or one of "udp" and "tcp".
 #
+# @param manage_resolv_conf
+#   For when `manage_resolved` is `true` should the file `/etc/resolv.conf` be managed.
+#
 # @param use_stub_resolver
 #   Takes a boolean argument. When "false" (default) it uses /run/systemd/resolve/resolv.conf
 #   as /etc/resolv.conf. When "true", it uses /run/systemd/resolve/stub-resolv.conf
@@ -171,6 +174,7 @@ class systemd (
   Variant[Boolean,Enum['yes', 'opportunistic', 'no']] $dnsovertls = false,
   Variant[Boolean,Enum['no-negative']]                $cache = false,
   Optional[Variant[Boolean,Enum['udp','tcp']]]        $dns_stub_listener = undef,
+  Boolean                                             $manage_resolv_conf = true,
   Boolean                                             $use_stub_resolver = false,
   Boolean                                             $manage_networkd = false,
   Enum['stopped','running']                           $networkd_ensure = 'running',

--- a/manifests/resolved.pp
+++ b/manifests/resolved.pp
@@ -71,14 +71,16 @@ class systemd::resolved (
     enable => $_enable_resolved,
   }
 
-  $_resolv_conf_target = $use_stub_resolver ? {
-    true    => '/run/systemd/resolve/stub-resolv.conf',
-    default => '/run/systemd/resolve/resolv.conf',
-  }
-  file { '/etc/resolv.conf':
-    ensure  => 'symlink',
-    target  => $_resolv_conf_target,
-    require => Service['systemd-resolved'],
+  if $systemd::manage_resolv_conf {
+    $_resolv_conf_target = $use_stub_resolver ? {
+      true    => '/run/systemd/resolve/stub-resolv.conf',
+      default => '/run/systemd/resolve/resolv.conf',
+    }
+    file { '/etc/resolv.conf':
+      ensure  => 'symlink',
+      target  => $_resolv_conf_target,
+      require => Service['systemd-resolved'],
+    }
   }
 
   if $dns {

--- a/spec/classes/init_spec.rb
+++ b/spec/classes/init_spec.rb
@@ -29,6 +29,7 @@ describe 'systemd' do
 
           it { is_expected.to create_service('systemd-resolved').with_ensure('running') }
           it { is_expected.to create_service('systemd-resolved').with_enable(true) }
+          it { is_expected.to contain_file('/etc/resolv.conf') }
           it { is_expected.to create_service('systemd-networkd').with_ensure('running') }
           it { is_expected.to create_service('systemd-networkd').with_enable(true) }
           it { is_expected.not_to contain_file('/etc/systemd/network') }
@@ -38,6 +39,17 @@ describe 'systemd' do
             it { is_expected.to contain_package('systemd-resolved') }
           else
             it { is_expected.not_to contain_package('systemd-resolved') }
+          end
+          context 'with manage_resolv_conf false' do
+            let(:params) { super().merge(manage_resolv_conf: false) }
+
+            it { is_expected.not_to contain_file('/etc/resolv.conf') }
+          end
+
+          context 'with manage_resolv_conf true' do
+            let(:params) { super().merge(manage_resolv_conf: true) }
+
+            it { is_expected.to contain_file('/etc/resolv.conf') }
           end
         end
 


### PR DESCRIPTION
#### Pull Request (PR) description
If the parameter is true (default) then `/etc/resolv.conf` will
be managed when `manage_resolved` is true.

