### PR TITLE
Install systemd-resolved on RedHat 7

### DIFF
--- a/README.md
+++ b/README.md
@@ -306,7 +306,7 @@ class{'systemd':
 }
 ```
 
-when `manage_systemd` is true any required sub package, e.g. `systemd-resolved` on CentOS 8, will be installed. However configuration of
+when `manage_systemd` is true any required sub package, e.g. `systemd-resolved` on CentOS 9, will be installed. However configuration of
 systemd-resolved will only occur on second puppet run after that installation.
 
 This requires [puppetlabs-inifile](https://forge.puppet.com/puppetlabs/inifile), which is only a soft dependency in this module (you need to explicitly install it). Both parameters accept a string or an array.

--- a/data/RedHat-7.yaml
+++ b/data/RedHat-7.yaml
@@ -1,4 +1,6 @@
 ---
+systemd::resolved_package: 'systemd-resolved'
+
 systemd::accounting:
   DefaultCPUAccounting: 'yes'
   DefaultBlockIOAccounting: 'yes'

--- a/spec/acceptance/resolved_spec.rb
+++ b/spec/acceptance/resolved_spec.rb
@@ -12,13 +12,12 @@ describe 'systemd with manage_resolved true' do
       }
       PUPPET
       apply_manifest(pp, catch_failures: true)
-      # RedHat 9 and newer installs package first run before fact  $facts['internal_services'] is set
-      apply_manifest(pp, catch_failures: true) if Gem::Version.new(fact('os.release.major')) >= Gem::Version.new('9') && (fact('os.family') == 'RedHat')
+      # RedHat 7, 9 and newer installs package first run before fact $facts['internal_services'] is set
+      apply_manifest(pp, catch_failures: true) if fact('os.release.major') != '8' && (fact('os.family') == 'RedHat')
       apply_manifest(pp, catch_changes: true)
     end
 
-    # RedHat 7 does not have systemd-resolved available at all.
-    describe service('systemd-resolved'), unless: (fact('os.release.major') == '7' and fact('os.family') == 'RedHat') do
+    describe service('systemd-resolved') do
       it { is_expected.to be_running }
       it { is_expected.to be_enabled }
     end
@@ -34,8 +33,6 @@ describe 'systemd with manage_resolved true' do
       }
       PUPPET
       apply_manifest(pp, catch_failures: true)
-      # RedHat 9 and newer installs package first run before fact  $facts['internal_services'] is set
-      apply_manifest(pp, catch_failures: true) if Gem::Version.new(fact('os.release.major')) >= Gem::Version.new('9') && (fact('os.family') == 'RedHat')
       apply_manifest(pp, catch_changes: true)
     end
 

--- a/spec/classes/init_spec.rb
+++ b/spec/classes/init_spec.rb
@@ -36,7 +36,7 @@ describe 'systemd' do
           it { is_expected.not_to contain_file('/etc/systemd/network') }
 
           case [facts[:os]['family'], facts[:os]['release']['major']]
-          when %w[RedHat 9]
+          when %w[RedHat 7], %w[RedHat 9]
             it { is_expected.to contain_package('systemd-resolved') }
           else
             it { is_expected.not_to contain_package('systemd-resolved') }


### PR DESCRIPTION
#### Pull Request (PR) description
Following #246 and #254 systemd-resolved was installed on family
RedHat 9 only.

On RedHat 7 a systemd-resolved package is now installed.

For information it is only RedHat 8 that does not have a systemd
resolved package.