### PR TITLE
dropin_file: Implement service_parameters hash

### DIFF
--- a/REFERENCE.md
+++ b/REFERENCE.md
@@ -1224,6 +1224,7 @@ The following parameters are available in the `systemd::unit_file` defined type:
 * [`hasrestart`](#hasrestart)
 * [`hasstatus`](#hasstatus)
 * [`selinux_ignore_defaults`](#selinux_ignore_defaults)
+* [`service_parameters`](#service_parameters)
 
 ##### <a name="name"></a>`name`
 
@@ -1356,6 +1357,14 @@ Data type: `Boolean`
 maps to the same param on the file resource for the unit. false in the module because it's false in the file resource type
 
 Default value: ``false``
+
+##### <a name="service_parameters"></a>`service_parameters`
+
+Data type: `Hash`
+
+hash that will be passed with the splat operator to the service resource
+
+Default value: `{}`
 
 ## Resource types
 

--- a/manifests/unit_file.pp
+++ b/manifests/unit_file.pp
@@ -58,6 +58,9 @@
 # @param selinux_ignore_defaults
 #   maps to the same param on the file resource for the unit. false in the module because it's false in the file resource type
 #
+# @param service_parameters
+#   hash that will be passed with the splat operator to the service resource
+#
 # @example manage unit file + service
 #   systemd::unit_file { 'foo.service':
 #     content => file("${module_name}/foo.service"),
@@ -81,6 +84,7 @@ define systemd::unit_file (
   Optional[Boolean]                        $hasrestart = undef,
   Boolean                                  $hasstatus = true,
   Boolean                                  $selinux_ignore_defaults = false,
+  Hash[String[1], Any]                     $service_parameters = {},
 ) {
   include systemd
 
@@ -121,6 +125,7 @@ define systemd::unit_file (
       provider   => 'systemd',
       hasrestart => $hasrestart,
       hasstatus  => $hasstatus,
+      *          => $service_parameters,
     }
 
     if $ensure == 'absent' {

--- a/spec/defines/unit_file_spec.rb
+++ b/spec/defines/unit_file_spec.rb
@@ -89,8 +89,54 @@ describe 'systemd::unit_file' do
               with_provider('systemd').
               with_hasstatus(true).
               without_hasrestart.
+              without_flags.
+              without_timeout.
               that_subscribes_to("File[/etc/systemd/system/#{title}]")
           end
+        end
+
+        context 'with enable => true and active => true and service_parameters' do
+          let(:params) do
+            super().merge(
+              enable: true,
+              active: true,
+              service_parameters: {
+                flags: '--awesome',
+                timeout: 1337
+              }
+            )
+          end
+
+          it { is_expected.to compile.with_all_deps }
+
+          it do
+            expect(subject).to contain_service('test.service').
+              with_ensure(true).
+              with_enable(true).
+              with_provider('systemd').
+              with_hasstatus(true).
+              without_hasrestart.
+              with_flags('--awesome').
+              with_timeout(1337).
+              that_subscribes_to("File[/etc/systemd/system/#{title}]")
+          end
+        end
+
+        context 'with enable => true and active => true and service_parameters and duplicate param' do
+          let(:params) do
+            super().merge(
+              enable: true,
+              active: true,
+              hasrestart: true,
+              service_parameters: {
+                flags: '--awesome',
+                timeout: 1337,
+                hasrestart: false
+              }
+            )
+          end
+
+          it { is_expected.not_to compile }
         end
 
         context 'hasrestart => true' do


### PR DESCRIPTION
This allows people to pass all options the service resource type accepts
to `systemd::dropin_file`. This is required to enable people to make a
migration from legacy code with systemd reload + file/service resource
to this module.

<!--
Thank you for contributing to this project!

- This project has a Contributor Code of Conduct: https://voxpupuli.org/coc/
- Please check that here is no existing issue or PR that addresses your problem.
- Our vulnerabilities reporting process is at https://voxpupuli.org/security/

-->
#### Pull Request (PR) description
<!--
Replace this comment with a description of your pull request.
-->

#### This Pull Request (PR) fixes the following issues
<!--
Replace this comment with the list of issues or n/a.
Use format:
Fixes #123
Fixes #124
-->
