### PR TITLE
systemd::udev::rule: param rules now defaults to `[]` / fix broken tests

### DIFF
--- a/manifests/udev/rule.pp
+++ b/manifests/udev/rule.pp
@@ -23,7 +23,7 @@
 #   The literal udev rules you want to deploy
 #
 define systemd::udev::rule (
-  Array                             $rules,
+  Array                             $rules                   = [],
   Enum['present', 'absent', 'file'] $ensure                  = 'present',
   Stdlib::Absolutepath              $path                    = '/etc/udev/rules.d',
   Variant[Array[String[1]], String[1]] $notify_services      = [],
@@ -33,6 +33,9 @@ define systemd::udev::rule (
 
   $filename = assert_type(Pattern['^.+\.rules$'], $name) |$expected, $actual| {
     fail("The \$name should match \'${expected}\', you passed \'${actual}\'")
+  }
+  if $ensure in ['file', 'present'] and empty($rules) {
+    fail("systemd::udev::rule - ${name}: param rules is empty, you need to pass rules")
   }
 
   file { $filename:

--- a/manifests/udev/rule.pp
+++ b/manifests/udev/rule.pp
@@ -38,12 +38,11 @@ define systemd::udev::rule (
     fail("systemd::udev::rule - ${name}: param rules is empty, you need to pass rules")
   }
 
-  file { $filename:
+  file { join([$path, $name], '/'):
     ensure                  => $ensure,
     owner                   => 'root',
     group                   => 'root',
     mode                    => '0444',
-    path                    => join([$path, $name], '/'),
     notify                  => $notify_services,
     selinux_ignore_defaults => $selinux_ignore_defaults,
     content                 => epp("${module_name}/udev_rule.epp", { 'rules' => $rules }),

--- a/manifests/udev/rule.pp
+++ b/manifests/udev/rule.pp
@@ -24,7 +24,7 @@
 #
 define systemd::udev::rule (
   Array                             $rules                   = [],
-  Enum['present', 'absent', 'file'] $ensure                  = 'present',
+  Enum['present', 'absent', 'file'] $ensure                  = 'file',
   Stdlib::Absolutepath              $path                    = '/etc/udev/rules.d',
   Variant[Array[String[1]], String[1]] $notify_services      = [],
   Boolean                           $selinux_ignore_defaults = false,

--- a/spec/defines/udev_rules_spec.rb
+++ b/spec/defines/udev_rules_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'spec_helper'
 
 describe 'systemd::udev::rule' do
@@ -8,13 +10,20 @@ describe 'systemd::udev::rule' do
 
         let(:title) { 'test.rules' }
 
+        let(:pre_condition) do
+          <<-PUPPET
+          class { 'systemd': manage_udevd => true, manage_journald => false }
+          service { 'foo': }
+          PUPPET
+        end
+
         describe 'with all options (one notify)' do
           let(:params) do
             {
               ensure: 'present',
               path: '/etc/udev/rules.d',
               selinux_ignore_defaults: false,
-              notify_services: "Service['systemd-udevd']",
+              notify_services: 'Service[systemd-udevd]',
               rules: [
                 '# I am a comment',
                 'ACTION=="add", KERNEL=="sda", RUN+="/bin/raw /dev/raw/raw1 %N"',
@@ -24,14 +33,22 @@ describe 'systemd::udev::rule' do
           end
 
           it { is_expected.to compile.with_all_deps }
+
           it {
             is_expected.to create_file("/etc/udev/rules.d/#{title}").
               with(ensure: 'file', mode: '0444', owner: 'root', group: 'root').
+              with_content(%r{^# This file managed by Puppet - DO NOT EDIT$}).
               with_content(%r{^# I am a comment$}).
-              with_content(%r{^ACTION=="add", KERNEL=="sda", RUN+="/bin/raw /dev/raw/raw1 %N"$}).
-              with_content(%r{^ACTION=="add", KERNEL=="sdb", RUN+="/bin/raw /dev/raw/raw2 %N"$}).
-              that_notifies("Service['systemd-udevd']")
+              with_content(%r{^ACTION=="add", KERNEL=="sda", RUN\+="/bin/raw /dev/raw/raw1 %N"$}).
+              with_content(%r{^ACTION=="add", KERNEL=="sdb", RUN\+="/bin/raw /dev/raw/raw2 %N"$}).
+              that_notifies('Service[systemd-udevd]')
           }
+
+          it { is_expected.to contain_class('systemd') }
+          it { is_expected.to contain_class('systemd::install') }
+          it { is_expected.to contain_class('systemd::udevd') }
+          it { is_expected.to contain_service('systemd-udevd') }
+          it { is_expected.to contain_file('/etc/udev/udev.conf') }
         end
 
         describe 'with all options (array notify)' do
@@ -40,7 +57,7 @@ describe 'systemd::udev::rule' do
               ensure: 'present',
               path: '/etc/udev/rules.d',
               selinux_ignore_defaults: false,
-              notify_services: ["Service['systemd-udevd']", "Service['foo']"],
+              notify_services: ['Service[systemd-udevd]', 'Service[foo]'],
               rules: [
                 '# I am a comment',
                 'ACTION=="add", KERNEL=="sda", RUN+="/bin/raw /dev/raw/raw1 %N"',
@@ -50,25 +67,36 @@ describe 'systemd::udev::rule' do
           end
 
           it { is_expected.to compile.with_all_deps }
+
           it {
             is_expected.to create_file("/etc/udev/rules.d/#{title}").
               with(ensure: 'file', mode: '0444', owner: 'root', group: 'root').
+              with_content(%r{^# This file managed by Puppet - DO NOT EDIT$}).
               with_content(%r{^# I am a comment$}).
-              with_content(%r{^ACTION=="add", KERNEL=="sda", RUN+="/bin/raw /dev/raw/raw1 %N"$}).
-              with_content(%r{^ACTION=="add", KERNEL=="sdb", RUN+="/bin/raw /dev/raw/raw2 %N"$}).
-              that_notifies("Service['systemd-udevd']").
-              that_notifies("Service['foo']")
+              with_content(%r{^ACTION=="add", KERNEL=="sda", RUN\+="/bin/raw /dev/raw/raw1 %N"$}).
+              with_content(%r{^ACTION=="add", KERNEL=="sdb", RUN\+="/bin/raw /dev/raw/raw2 %N"$}).
+              that_notifies('Service[systemd-udevd]').
+              that_notifies('Service[foo]')
           }
         end
 
-        describe 'ensured absent' do
-          let(:params) { { ensure: 'absent' } }
+        describe 'ensured absent without notify' do
+          let(:params) { { ensure: 'absent', } }
 
           it { is_expected.to compile.with_all_deps }
+
+          it { is_expected.to contain_file("/etc/udev/rules.d/#{title}").with_ensure('absent').with_notify([]) }
+        end
+
+        describe 'ensured absent with notify' do
+          let(:params) { { ensure: 'absent', notify_services: 'Service[systemd-udevd]', } }
+
+          it { is_expected.to compile.with_all_deps }
+
           it do
             is_expected.to create_file("/etc/udev/rules.d/#{title}").
               with_ensure('absent').
-              that_notifies("Service['systemd-udevd']")
+              that_notifies('Service[systemd-udevd]')
           end
         end
       end

--- a/spec/defines/udev_rules_spec.rb
+++ b/spec/defines/udev_rules_spec.rb
@@ -20,7 +20,7 @@ describe 'systemd::udev::rule' do
         describe 'with all options (one notify)' do
           let(:params) do
             {
-              ensure: 'present',
+              ensure: 'file',
               path: '/etc/udev/rules.d',
               selinux_ignore_defaults: false,
               notify_services: 'Service[systemd-udevd]',
@@ -54,7 +54,7 @@ describe 'systemd::udev::rule' do
         describe 'with all options (array notify)' do
           let(:params) do
             {
-              ensure: 'present',
+              ensure: 'file',
               path: '/etc/udev/rules.d',
               selinux_ignore_defaults: false,
               notify_services: ['Service[systemd-udevd]', 'Service[foo]'],


### PR DESCRIPTION
<!--
Thank you for contributing to this project!

- This project has a Contributor Code of Conduct: https://voxpupuli.org/coc/
- Please check that here is no existing issue or PR that addresses your problem.
- Our vulnerabilities reporting process is at https://voxpupuli.org/security/

-->
#### Pull Request (PR) description
<!--
Replace this comment with a description of your pull request.
-->

#### This Pull Request (PR) fixes the following issues
<!--
Replace this comment with the list of issues or n/a.
Use format:
Fixes #123
Fixes #124
-->
