### PR TITLE
unit_file: deprecate hasrestart/hasstatus params

### DIFF
--- a/REFERENCE.md
+++ b/REFERENCE.md
@@ -1153,7 +1153,7 @@ Data type: `Enum['present', 'absent', 'file']`
 
 Whether to drop a file or remove it
 
-Default value: `'present'`
+Default value: `'file'`
 
 ##### <a name="path"></a>`path`
 
@@ -1184,6 +1184,8 @@ Default value: `[]`
 Data type: `Array`
 
 The literal udev rules you want to deploy
+
+Default value: `[]`
 
 ### <a name="systemdunit_file"></a>`systemd::unit_file`
 
@@ -1338,7 +1340,7 @@ Default value: ``undef``
 
 Data type: `Optional[Boolean]`
 
-maps to the same param on the service resource. Optional in the module because it's optional in the service resource type
+maps to the same param on the service resource. Optional in the module because it's optional in the service resource type. This param is deprecated. Set it via $service_parameters.
 
 Default value: ``undef``
 
@@ -1346,7 +1348,7 @@ Default value: ``undef``
 
 Data type: `Boolean`
 
-maps to the same param on the service resource. true in the module because it's true in the service resource type
+maps to the same param on the service resource. true in the module because it's true in the service resource type. This param is deprecated. Set it via $service_parameters.
 
 Default value: ``true``
 
@@ -1360,7 +1362,7 @@ Default value: ``false``
 
 ##### <a name="service_parameters"></a>`service_parameters`
 
-Data type: `Hash`
+Data type: `Hash[String[1], Any]`
 
 hash that will be passed with the splat operator to the service resource
 

--- a/manifests/unit_file.pp
+++ b/manifests/unit_file.pp
@@ -50,10 +50,10 @@
 #   Specify a restart command manually. If left unspecified, a standard Puppet service restart happens.
 #
 # @param hasrestart
-#   maps to the same param on the service resource. Optional in the module because it's optional in the service resource type
+#   maps to the same param on the service resource. Optional in the module because it's optional in the service resource type. This param is deprecated. Set it via $service_parameters.
 #
 # @param hasstatus
-#   maps to the same param on the service resource. true in the module because it's true in the service resource type
+#   maps to the same param on the service resource. true in the module because it's true in the service resource type. This param is deprecated. Set it via $service_parameters.
 #
 # @param selinux_ignore_defaults
 #   maps to the same param on the file resource for the unit. false in the module because it's false in the file resource type
@@ -82,13 +82,21 @@ define systemd::unit_file (
   Optional[Boolean]                        $active    = undef,
   Optional[String]                         $restart   = undef,
   Optional[Boolean]                        $hasrestart = undef,
-  Boolean                                  $hasstatus = true,
+  Optional[Boolean]                        $hasstatus = undef,
   Boolean                                  $selinux_ignore_defaults = false,
   Hash[String[1], Any]                     $service_parameters = {},
 ) {
   include systemd
 
   assert_type(Systemd::Unit, $name)
+
+  if $hasrestart =~ NotUndef {
+    deprecation("systemd::unit_file - ${title}", 'hasrestart is deprecated and will be removed in Version 4 of the module')
+  }
+
+  if $hasstatus =~ NotUndef {
+    deprecation("systemd::unit_file - ${title}", 'hasstatus is deprecated and will be removed in Version 4 of the module')
+  }
 
   if $enable == 'mask' {
     $_target = '/dev/null'

--- a/spec/defines/unit_file_spec.rb
+++ b/spec/defines/unit_file_spec.rb
@@ -87,7 +87,7 @@ describe 'systemd::unit_file' do
               with_ensure(true).
               with_enable(true).
               with_provider('systemd').
-              with_hasstatus(true).
+              without_hasstatus.
               without_hasrestart.
               without_flags.
               without_timeout.
@@ -114,7 +114,7 @@ describe 'systemd::unit_file' do
               with_ensure(true).
               with_enable(true).
               with_provider('systemd').
-              with_hasstatus(true).
+              without_hasstatus.
               without_hasrestart.
               with_flags('--awesome').
               with_timeout(1337).
@@ -155,7 +155,7 @@ describe 'systemd::unit_file' do
               with_ensure(true).
               with_enable(true).
               with_provider('systemd').
-              with_hasstatus(true).
+              without_hasstatus.
               with_hasrestart(true).
               that_subscribes_to("File[/etc/systemd/system/#{title}]")
           end
@@ -177,7 +177,7 @@ describe 'systemd::unit_file' do
               with_ensure(true).
               with_enable(true).
               with_provider('systemd').
-              with_hasstatus(true).
+              without_hasstatus.
               with_hasrestart(false).
               that_subscribes_to("File[/etc/systemd/system/#{title}]")
           end


### PR DESCRIPTION
We now have a `$service_parameters` hash that's passed to the service
resource. It should be used to set hasrestart/hasstatus.

<!--
Thank you for contributing to this project!

- This project has a Contributor Code of Conduct: https://voxpupuli.org/coc/
- Please check that here is no existing issue or PR that addresses your problem.
- Our vulnerabilities reporting process is at https://voxpupuli.org/security/

-->
#### Pull Request (PR) description
<!--
Replace this comment with a description of your pull request.
-->

#### This Pull Request (PR) fixes the following issues
<!--
Replace this comment with the list of issues or n/a.
Use format:
Fixes #123
Fixes #124
-->
