### PR TITLE
Add CentOS 9 to supported operating systems

### DIFF
--- a/metadata.json
+++ b/metadata.json
@@ -60,7 +60,8 @@
       "operatingsystem": "CentOS",
       "operatingsystemrelease": [
         "7",
-        "8"
+        "8",
+        "9"
       ]
     },
     {


### PR DESCRIPTION
#### Pull Request (PR) description
This is follow-up of 1698451e2069f4c067ba394a05703aa559c03863 and adds
CentOS 9 to supported operating systems. The required logic was
implemented by that change but the supported versions of CentOS were
not updated by that commit.

#### This Pull Request (PR) fixes the following issues
n/a
