### PR TITLE
Ensure systemd-networkd is available piror notifing service

### DIFF
--- a/manifests/network.pp
+++ b/manifests/network.pp
@@ -26,7 +26,7 @@ define systemd::network (
 ) {
   include systemd
 
-  if $restart_service and $systemd::manage_networkd {
+  if $restart_service and $systemd::manage_networkd and $facts['systemd_internal_services'] and $facts['systemd_internal_services']['systemd-networkd.service'] {
     $notify = Service['systemd-networkd']
   } else {
     $notify = undef


### PR DESCRIPTION
#### Pull Request (PR) description
In the current version of this module there's a dependency problem if `systemd-networkd` is not already installed prior the initial puppet run.

The class `systemd::networkd`, which includes the `service` resource of `systemd-networkd` is only [included within the `init.pp` if the fact `systemd_internal_services` includes `systemd-networkd.service`](https://github.com/voxpupuli/puppet-systemd/blob/master/manifests/init.pp#L244) which is false until the package `systemd-networkd` has been installed. Unfortunately the  class `systemd::network` tries to notify the service already [if `manage_networkd` is set to `true`](https://github.com/voxpupuli/puppet-systemd/blob/master/manifests/network.pp#L29) and does not check that the fact `systemd_internal_services` which leads to the following errror

```
Error: Could not retrieve catalog from remote server: Error 500 on SERVER: Server Error: Could not find resource 'Service[systemd-networkd]' in parameter 'notify' (file: /etc/puppetlabs/code/modules/systemd/manifests/network.pp, line: 33) on node xxxxx
```

This PR adds the same fact checks to the network class. 