### PR TITLE
Add parameter to manage default target

### DIFF
--- a/README.md
+++ b/README.md
@@ -259,6 +259,8 @@ systemd::network{'eth0.network':
 
 ### Services
 
+The default target is managed via the `default_target` parameter.  If this is left at its default value (`undef`), the default-target will be unmanaged by puppet.
+
 Systemd provides multiple services. Currently you can manage `systemd-resolved`,
 `systemd-timesyncd`, `systemd-networkd`, `systemd-journald`, `systemd-coredump`
 and `systemd-logind`

--- a/spec/classes/init_spec.rb
+++ b/spec/classes/init_spec.rb
@@ -18,6 +18,7 @@ describe 'systemd' do
         it { is_expected.not_to create_service('systemd-timesyncd') }
         it { is_expected.not_to contain_package('systemd-resolved') }
         it { is_expected.not_to contain_class('systemd::coredump') }
+        it { is_expected.not_to contain_exec('systemctl set-default multi-user.target') }
 
         context 'when enabling resolved and networkd' do
           let(:params) do
@@ -179,6 +180,17 @@ describe 'systemd' do
               value: 'no-negative'
             )
           }
+        end
+
+        context 'with alternate target' do
+          let(:params) do
+            {
+              default_target: 'example.target',
+            }
+          end
+
+          it { is_expected.to contain_exec('systemctl set-default example.target') }
+          it { is_expected.to contain_service('example.target').with_enable(true).with_ensure('running') }
         end
 
         context 'when enabling timesyncd' do


### PR DESCRIPTION
#### Pull Request (PR) description
I was a bit surprised to discover that the default target for systemd was not already something this class managed.

Merging this should probably result in a meaningful version bump since folks who want a different target will need to set one explicitly.  The default from systemd upstream is multi-user.target thus that is what I selected.