### PR TITLE
systemd::resolved: save readlink's value to avoid calling it twice

### DIFF
--- a/manifests/resolved.pp
+++ b/manifests/resolved.pp
@@ -88,7 +88,7 @@ class systemd::resolved (
       # reboot.
       exec { 'restore_resolv.conf_if_possible':
         command => 'cp --remove-destination -f /run/systemd/resolve/resolv.conf /etc/resolv.conf',
-        onlyif  => 'test "$(readlink /etc/resolv.conf)" = "/run/systemd/resolve/resolv.conf"  || test "$(readlink /etc/resolv.conf)" = "/run/systemd/resolve/stub-resolv.conf"',
+        onlyif  => 'l="$(readlink /etc/resolv.conf)"; test "$l" = "/run/systemd/resolve/resolv.conf" || test "$l" = "/run/systemd/resolve/stub-resolv.conf',
         path    => $facts['path'],
       }
     }


### PR DESCRIPTION
This is a trivial/tiny optimization.