### PR TITLE
Add comment hint about initrd for folks

### DIFF
--- a/templates/udev_conf.epp
+++ b/templates/udev_conf.epp
@@ -8,6 +8,10 @@
 | -%>
 # This file managed by Puppet - DO NOT EDIT
 #
+# udevd is also started in the initrd.  When this file is modified you might
+# also want to rebuild the initrd, so that it will include the modified
+# configuration.  See udev.conf(5) for options and details.
+#
 # The initial syslog(3) priority: "err", "info", "debug" or its
 # numerical equivalent. For runtime debugging, the daemons internal
 # state can be changed with: "udevadm control --log-priority=<value>".


### PR DESCRIPTION
#### Pull Request (PR) description
These days systemd-udev includes a note about udev in the initrd.  Adding that comment to the template for folks so they have a hint about why their udev.conf changes may not be taking effect.

#### This Pull Request (PR) fixes the following issues
N/A