### PR TITLE
New systemd::simpletimer type

### DIFF
--- a/README.md
+++ b/README.md
@@ -216,6 +216,22 @@ systemd::timer{'daily.timer':
 }
 ```
 
+### simple timer units
+
+For the simple cases of timers such as running a command once per day
+
+```puppet
+systemd::simpletimer { 'onceperday.timer':
+  enusre  => present,
+  command => '/usr/bin/touch /tmp/today',
+  timings => {
+    'OnCalendar' => 'daily',
+  },
+}
+```
+
+can be used. The service and timer unit files will be generated from templates.
+
 ### service limits
 
 Manage soft and hard limits on various resources for executed processes.

--- a/README.md
+++ b/README.md
@@ -222,7 +222,7 @@ For the simple cases of timers such as running a command once per day
 
 ```puppet
 systemd::simpletimer { 'onceperday.timer':
-  enusre  => present,
+  ensure  => present,
   command => '/usr/bin/touch /tmp/today',
   timings => {
     'OnCalendar' => 'daily',

--- a/REFERENCE.md
+++ b/REFERENCE.md
@@ -33,6 +33,7 @@
 * [`systemd::modules_load`](#systemdmodules_load): Creates a modules-load.d drop file
 * [`systemd::network`](#systemdnetwork): Creates network config for systemd-networkd
 * [`systemd::service_limits`](#systemdservice_limits): Adds a set of custom limits to the service
+* [`systemd::simpletimer`](#systemdsimpletimer): Configures oneshot service and timer for trivial commands
 * [`systemd::timer`](#systemdtimer): Create a timer and optionally a service unit to execute with the timer unit
 * [`systemd::tmpfile`](#systemdtmpfile): Creates a systemd tmpfile
 * [`systemd::udev::rule`](#systemdudevrule): Adds a custom udev rule
@@ -997,6 +998,119 @@ Data type: `Boolean`
 Restart the managed service after setting the limits
 
 Default value: ``true``
+
+### <a name="systemdsimpletimer"></a>`systemd::simpletimer`
+
+Configures oneshot service and timer for trivial commands
+
+* **See also**
+  * https://www.freedesktop.org/software/systemd/man/systemd.timer.html
+    * systemd.timer(5)
+
+#### Examples
+
+##### Run a command on boot and once per hour thereafter
+
+```puppet
+systemd::simpletimer { 'create-file.timer':
+  ensure              => present,
+  command             => '/usr/bin/touch /tmp/file',
+  timings             => {
+    'OnBootsec'       => 0,
+    'OnUnitActiveSec' => '1h',
+  }
+  enable              => true,
+  active              => true,
+```
+
+##### Run a command weekly only after the network is up
+
+```puppet
+systemd::simpletimer { 'create-file-weekly.timer':
+  ensure              => present,
+  command             => '/usr/bin/touch /tmp/weekly',
+  description         => 'Touch a file',
+  timings             => {
+    'OnCalendar' => 'weekly',
+  },
+  enable              => true,
+  active              => true,
+  after               => ['network-online.target'],
+}
+```
+
+#### Parameters
+
+The following parameters are available in the `systemd::simpletimer` defined type:
+
+* [`name`](#name)
+* [`description`](#description)
+* [`command`](#command)
+* [`timings`](#timings)
+* [`ensure`](#ensure)
+* [`active`](#active)
+* [`enable`](#enable)
+* [`after`](#after)
+
+##### <a name="name"></a>`name`
+
+Data type: `Pattern['^.+\.timer$]`
+
+The target of the timer unit to create
+
+##### <a name="description"></a>`description`
+
+Data type: `Optional[String[1]]`
+
+Specity a timer description to add to service and timer unit files
+
+Default value: ``undef``
+
+##### <a name="command"></a>`command`
+
+Data type: `String[1]`
+
+Command line and options to run
+
+##### <a name="timings"></a>`timings`
+
+Data type: `Hash[Enum['OnActiveSec', 'OnBootSec', 'OnStartupSec', 'OnUnitActiveSec', 'OnUnitInactiveSec', 'OnCalendar'],Variant[String[1],Integer],1]`
+
+Specify timing parameters for timer unit as to when the timer should run
+
+##### <a name="ensure"></a>`ensure`
+
+Data type: `Enum['present', 'absent']`
+
+Defines the desired state of the timer
+
+Default value: `'present'`
+
+##### <a name="active"></a>`active`
+
+Data type: `Optional[Boolean]`
+
+If set to true or false the timer service will be maintained.
+If true the timer service will be running and enabled, if false it will
+explicitly stopped and disabled.
+
+Default value: ``undef``
+
+##### <a name="enable"></a>`enable`
+
+Data type: `Optional[Variant[Boolean, Enum['mask']]]`
+
+If set, will manage the state of the unit.
+
+Default value: ``undef``
+
+##### <a name="after"></a>`after`
+
+Data type: `Optional[Array[Systemd::Unit,1]]`
+
+List of systemd units the service will only run `After`
+
+Default value: ``undef``
 
 ### <a name="systemdtimer"></a>`systemd::timer`
 

--- a/manifests/simpletimer.pp
+++ b/manifests/simpletimer.pp
@@ -1,0 +1,71 @@
+# @summary Configures oneshot service and timer for trivial commands
+#
+# @api public
+#
+# @see https://www.freedesktop.org/software/systemd/man/systemd.timer.html systemd.timer(5)
+#
+# @param name [Pattern['^.+\.timer$]]
+#   The target of the timer unit to create
+#
+# @param description Specity a timer description to add to service and timer unit files
+#
+# @param command Command line and options to run
+#
+# @param timings Specify timing parameters for timer unit as to when the timer should run
+#
+# @param ensure
+#   Defines the desired state of the timer
+#
+# @param active
+#  If set to true or false the timer service will be maintained.
+#  If true the timer service will be running and enabled, if false it will
+#  explicitly stopped and disabled.
+#
+# @param enable
+#   If set, will manage the state of the unit.
+#
+# @param after List of systemd units the service will only run `After`
+#
+# @example Run a command on boot and once per hour thereafter
+#   systemd::simpletimer { 'create-file.timer':
+#     ensure              => present,
+#     command             => '/usr/bin/touch /tmp/file',
+#     timings             => {
+#       'OnBootsec'       => 0,
+#       'OnUnitActiveSec' => '1h',
+#     }
+#     enable              => true,
+#     active              => true,
+#
+# @example Run a command weekly only after the network is up
+#   systemd::simpletimer { 'create-file-weekly.timer':
+#     ensure              => present,
+#     command             => '/usr/bin/touch /tmp/weekly',
+#     description         => 'Touch a file',
+#     timings             => {
+#       'OnCalendar' => 'weekly',
+#     },
+#     enable              => true,
+#     active              => true,
+#     after               => ['network-online.target'],
+#   }
+#
+define systemd::simpletimer (
+  String[1] $command,
+  Hash[Enum['OnActiveSec', 'OnBootSec', 'OnStartupSec', 'OnUnitActiveSec', 'OnUnitInactiveSec', 'OnCalendar'],Variant[String[1],Integer],1] $timings,
+  Optional[String[1]] $description                 = undef,
+  Enum['present', 'absent'] $ensure                = 'present',
+  Optional[Variant[Boolean, Enum['mask']]] $enable = undef,
+  Optional[Boolean]                        $active = undef,
+  Optional[Array[Systemd::Unit,1]]         $after  = undef,
+) {
+  assert_type(Pattern['^.+\.timer$'],$name)
+
+  systemd::timer { $name:
+    ensure          => $ensure,
+    enable          => $enable,
+    active          => $active,
+    timer_content   => epp('systemd/simpletimer.timer.epp',   { 'description' => $description, 'timings' => $timings }),
+    service_content => epp('systemd/simpletimer.service.epp', { 'description' => $description, 'command' => $command, 'after' => $after }),
+  }
+}

--- a/spec/defines/simpletimer_spec.rb
+++ b/spec/defines/simpletimer_spec.rb
@@ -1,0 +1,75 @@
+# frozen_string_literal: true
+
+require 'spec_helper'
+
+describe 'systemd::simpletimer' do
+  context 'supported operating systems' do
+    on_supported_os.each do |os, facts|
+      context "on #{os}" do
+        let(:facts) { facts }
+
+        let(:title) { 'foobar.timer' }
+
+        context('with command and weekly job') do
+          let(:params) do
+            {
+              command: '/usr/bin/touch /tmp/file',
+              timings: { OnCalendar: 'weekly' },
+            }
+          end
+
+          it { is_expected.to compile.with_all_deps }
+
+          it {
+            is_expected.to contain_systemd__timer('foobar.timer').with(
+              {
+                ensure: 'present',
+                timer_content: %r{^OnCalendar=weekly$},
+                service_content: %r{^ExecStart=/usr/bin/touch /tmp/file$},
+              }
+            ).with(
+              {
+                timer_content: %r{^Description=Puppet configured timer$},
+                service_content: %r{^Description=Puppet configured service$},
+              }
+            )
+          }
+        end
+
+        context('on boot then once per hour after network and foo') do
+          let(:params) do
+            {
+              command: '/usr/bin/touch /tmp/file',
+              description: 'my special timer',
+              timings: {
+                OnBootSec: 0,
+                OnActiveSec: '1h',
+              },
+              after: ['network.service', 'foo.service'],
+            }
+          end
+
+          it {
+            is_expected.to contain_systemd__timer('foobar.timer').with(
+              {
+                ensure: 'present',
+                timer_content: %r{^OnActiveSec=1h$},
+                service_content: %r{^ExecStart=/usr/bin/touch /tmp/file$},
+              }
+            ).with(
+              {
+                timer_content: %r{^OnBootSec=0$},
+                service_content: %r{^After=network.service, foo.service$},
+              }
+            ).with(
+              {
+                timer_content: %r{^Description=Puppet configured timer : my special timer$},
+                service_content: %r{^Description=Puppet configured service : my special timer$},
+              }
+            )
+          }
+        end
+      end
+    end
+  end
+end

--- a/templates/simpletimer.service.epp
+++ b/templates/simpletimer.service.epp
@@ -1,0 +1,14 @@
+<%- |
+  Optional[String[1]] $description = undef,
+  Optional[Array[String[1]]] $after = undef,
+  String[1] $command,
+|-%>
+[Unit]
+Description=Puppet configured service<% if $description { %> : <%= $description %><% } %>
+<% if $after { -%>
+After=<%= $after.join(', ') %>
+<%- } -%>
+
+[Service]
+Type=oneshot
+ExecStart=<%= $command %>

--- a/templates/simpletimer.timer.epp
+++ b/templates/simpletimer.timer.epp
@@ -1,0 +1,14 @@
+<%- |
+  Optional[String[1]] $description = undef,
+  Hash[String[1],Variant[String[1],Integer],1] $timings
+| %>
+[Unit]
+Description=Puppet configured timer<% if $description { %> : <%= $description %><% } %>
+
+[Timer]
+<% $timings.each | $_key, $_value | { -%>
+<%= $_key %>=<%= $_value %>
+<% } -%>
+
+[Install]
+WantedBy=timers.target


### PR DESCRIPTION
#### Pull Request (PR) description

Addition of a new type

```puppet
systemd::simpletimer{'onceperday.timer':
  enusre  => present,
  command => '/usr/bin/touch /tmp/today'
  timings => {
    'OnCalendar' => 'daily',
  },
}
```

would run a command once per day generating units and services from templates.

Motivation here is to make (the majority) of timers as easy to add as cron jobs.
