### PR TITLE
New systemd::manage_unit, systemd::manage_dropin types

### DIFF
--- a/README.md
+++ b/README.md
@@ -59,6 +59,30 @@ systemd::unit_file { 'foo.service':
 }
 ```
 
+### unit files from parameters
+
+Create a unit file from parameters
+
+```puppet
+systemd::manage_unit { 'myrunner.service':
+  $unit_entry    => {
+    'Description' => 'My great service',
+  },
+  $service_entry => {
+    'Type'       => 'oneshot',
+    'ExecStart' => '/usr/bin/doit.sh',
+  },
+  $install_entry => {
+    'WantedBy' => 'multi-user.target',
+  },
+  enable         => true,
+  active         => true,
+}
+```
+
+The parameters `unit_entry`, `service_entry` and `install_entry` populate the
+`[Unit]`, `[Service]` and `[Install]` sections of the generated unit file.
+
 ### drop-in files
 
 Drop-in files are used to add or alter settings of a unit without modifying the
@@ -104,6 +128,21 @@ systemd::dropin_files:
     unit: foo.service
     source: puppet:///modules/${module_name}/foo.conf
 ```
+
+### drop-in files from parameters
+
+```puppet
+systemd::manage_dropin { 'myconf.conf':
+  ensure        => present,
+  unit          => 'myservice.service',
+  service_entry => {
+    'Type'      => 'oneshot',
+    'ExecStart' => ['', '/usr/bin/doit.sh'],
+  },
+}
+```
+
+The filename of the drop in. The full path is determined using the path, unit and this filename.
 
 ### modules-load.d
 

--- a/REFERENCE.md
+++ b/REFERENCE.md
@@ -30,6 +30,8 @@
 
 * [`systemd::daemon_reload`](#systemddaemon_reload): Run systemctl daemon-reload
 * [`systemd::dropin_file`](#systemddropin_file): Creates a drop-in file for a systemd unit
+* [`systemd::manage_dropin`](#systemdmanage_dropin): Creates a drop-in file for a systemd unit from a template
+* [`systemd::manage_unit`](#systemdmanage_unit): Generate unit file from template
 * [`systemd::modules_load`](#systemdmodules_load): Creates a modules-load.d drop file
 * [`systemd::network`](#systemdnetwork): Creates network config for systemd-networkd
 * [`systemd::service_limits`](#systemdservice_limits): Adds a set of custom limits to the service
@@ -59,6 +61,10 @@
 * [`Systemd::OomdSettings`](#systemdoomdsettings): Configurations for oomd.conf
 * [`Systemd::ServiceLimits`](#systemdservicelimits): Matches Systemd Service Limit Struct
 * [`Systemd::Unit`](#systemdunit): custom datatype that validates different filenames for systemd units and unit templates
+* [`Systemd::Unit::Install`](#systemdunitinstall): Possible keys for the [Install] section of a unit file
+* [`Systemd::Unit::Service`](#systemdunitservice): Possible keys for the [Service] section of a unit file
+* [`Systemd::Unit::Service::Exec`](#systemdunitserviceexec): Possible strings for ExecStart, ExecStartPrep, ...
+* [`Systemd::Unit::Unit`](#systemdunitunit): Possible keys for the [Unit] section of a unit file
 
 ## Classes
 
@@ -742,6 +748,326 @@ Data type: `Boolean`
 Call systemd::daemon_reload
 
 Default value: ``true``
+
+### <a name="systemdmanage_dropin"></a>`systemd::manage_dropin`
+
+Creates a drop-in file for a systemd unit from a template
+
+* **See also**
+  * systemd.unit(5)
+
+#### Examples
+
+##### drop in file to change Type and override ExecStart
+
+```puppet
+systemd::manage_dropin { 'myconf.conf':
+  ensure        => present,
+  unit          => 'myservice.service',
+  service_entry => {
+    'Type'      => 'oneshot',
+    'ExecStart' => ['', '/usr/bin/doit.sh'],
+  },
+}
+```
+
+#### Parameters
+
+The following parameters are available in the `systemd::manage_dropin` defined type:
+
+* [`unit`](#unit)
+* [`filename`](#filename)
+* [`ensure`](#ensure)
+* [`path`](#path)
+* [`selinux_ignore_defaults`](#selinux_ignore_defaults)
+* [`owner`](#owner)
+* [`group`](#group)
+* [`mode`](#mode)
+* [`show_diff`](#show_diff)
+* [`notify_service`](#notify_service)
+* [`daemon_reload`](#daemon_reload)
+* [`unit_entry`](#unit_entry)
+* [`service_entry`](#service_entry)
+* [`install_entry`](#install_entry)
+
+##### <a name="unit"></a>`unit`
+
+Data type: `Systemd::Unit`
+
+The unit to create a dropfile for
+
+##### <a name="filename"></a>`filename`
+
+Data type: `Systemd::Dropin`
+
+The target unit file to create. The filename of the drop in. The full path is determined using the path, unit and this filename.
+
+Default value: `$name`
+
+##### <a name="ensure"></a>`ensure`
+
+Data type: `Enum['present', 'absent']`
+
+The state of this dropin file
+
+Default value: `'present'`
+
+##### <a name="path"></a>`path`
+
+Data type: `Stdlib::Absolutepath`
+
+The main systemd configuration path
+
+Default value: `'/etc/systemd/system'`
+
+##### <a name="selinux_ignore_defaults"></a>`selinux_ignore_defaults`
+
+Data type: `Boolean`
+
+If Puppet should ignore the default SELinux labels
+
+Default value: ``false``
+
+##### <a name="owner"></a>`owner`
+
+Data type: `String`
+
+The owner to set on the dropin file
+
+Default value: `'root'`
+
+##### <a name="group"></a>`group`
+
+Data type: `String`
+
+The group to set on the dropin file
+
+Default value: `'root'`
+
+##### <a name="mode"></a>`mode`
+
+Data type: `Stdlib::Filemode`
+
+The mode to set on the dropin file
+
+Default value: `'0444'`
+
+##### <a name="show_diff"></a>`show_diff`
+
+Data type: `Boolean`
+
+Whether to show the diff when updating dropin file
+
+Default value: ``true``
+
+##### <a name="notify_service"></a>`notify_service`
+
+Data type: `Boolean`
+
+Notify a service for the unit, if it exists
+
+Default value: ``false``
+
+##### <a name="daemon_reload"></a>`daemon_reload`
+
+Data type: `Boolean`
+
+Call systemd::daemon_reload
+
+Default value: ``true``
+
+##### <a name="unit_entry"></a>`unit_entry`
+
+Data type: `Optional[Systemd::Unit::Unit]`
+
+key value pairs for [Unit] section of the unit file
+
+Default value: ``undef``
+
+##### <a name="service_entry"></a>`service_entry`
+
+Data type: `Optional[Systemd::Unit::Service]`
+
+key value pairs for [Service] section of the unit file
+
+Default value: ``undef``
+
+##### <a name="install_entry"></a>`install_entry`
+
+Data type: `Optional[Systemd::Unit::Install]`
+
+key value pairs for [Install] section of the unit file
+
+Default value: ``undef``
+
+### <a name="systemdmanage_unit"></a>`systemd::manage_unit`
+
+Generate unit file from template
+
+* **See also**
+  * systemd.unit(5)
+
+#### Examples
+
+##### Generate a service
+
+```puppet
+systemd::manage_unit{ 'myrunner.service':
+  $unit_entry    => {
+    'Description' => 'My great service',
+  },
+  $service_entry => {
+    'Type'       => 'oneshot',
+    'ExecStart' => '/usr/bin/doit.sh',
+  },
+  $install_entry => {
+    WantedBy => 'multi-user.target',
+  },
+}
+```
+
+#### Parameters
+
+The following parameters are available in the `systemd::manage_unit` defined type:
+
+* [`name`](#name)
+* [`ensure`](#ensure)
+* [`path`](#path)
+* [`owner`](#owner)
+* [`group`](#group)
+* [`mode`](#mode)
+* [`show_diff`](#show_diff)
+* [`enable`](#enable)
+* [`active`](#active)
+* [`restart`](#restart)
+* [`selinux_ignore_defaults`](#selinux_ignore_defaults)
+* [`service_parameters`](#service_parameters)
+* [`daemon_reload`](#daemon_reload)
+* [`unit_entry`](#unit_entry)
+* [`service_entry`](#service_entry)
+* [`install_entry`](#install_entry)
+
+##### <a name="name"></a>`name`
+
+Data type: `Pattern['^[^/]+\.(service|socket|device|mount|automount|swap|target|path|timer|slice|scope)$']`
+
+The target unit file to create
+
+##### <a name="ensure"></a>`ensure`
+
+Data type: `Enum['present', 'absent']`
+
+The state of the unit file to ensure
+
+Default value: `'present'`
+
+##### <a name="path"></a>`path`
+
+Data type: `Stdlib::Absolutepath`
+
+The main systemd configuration path
+
+Default value: `'/etc/systemd/system'`
+
+##### <a name="owner"></a>`owner`
+
+Data type: `String`
+
+The owner to set on the unit file
+
+Default value: `'root'`
+
+##### <a name="group"></a>`group`
+
+Data type: `String`
+
+The group to set on the unit file
+
+Default value: `'root'`
+
+##### <a name="mode"></a>`mode`
+
+Data type: `Stdlib::Filemode`
+
+The mode to set on the unit file
+
+Default value: `'0444'`
+
+##### <a name="show_diff"></a>`show_diff`
+
+Data type: `Boolean`
+
+Whether to show the diff when updating unit file
+
+Default value: ``true``
+
+##### <a name="enable"></a>`enable`
+
+Data type: `Optional[Variant[Boolean, Enum['mask']]]`
+
+If set, manage the unit enablement status
+
+Default value: ``undef``
+
+##### <a name="active"></a>`active`
+
+Data type: `Optional[Boolean]`
+
+If set, will manage the state of the unit
+
+Default value: ``undef``
+
+##### <a name="restart"></a>`restart`
+
+Data type: `Optional[String]`
+
+Specify a restart command manually. If left unspecified, a standard Puppet service restart happens
+
+Default value: ``undef``
+
+##### <a name="selinux_ignore_defaults"></a>`selinux_ignore_defaults`
+
+Data type: `Boolean`
+
+maps to the same param on the file resource for the unit. false in the module because it's false in the file resource type
+
+Default value: ``false``
+
+##### <a name="service_parameters"></a>`service_parameters`
+
+Data type: `Hash[String[1], Any]`
+
+hash that will be passed with the splat operator to the service resource
+
+Default value: `{}`
+
+##### <a name="daemon_reload"></a>`daemon_reload`
+
+Data type: `Boolean`
+
+call `systemd::daemon-reload` to ensure that the modified unit file is loaded
+
+Default value: ``true``
+
+##### <a name="unit_entry"></a>`unit_entry`
+
+Data type: `Systemd::Unit::Unit`
+
+key value pairs for [Unit] section of the unit file.
+
+##### <a name="service_entry"></a>`service_entry`
+
+Data type: `Systemd::Unit::Service`
+
+key value pairs for [Service] section of the unit file.
+
+##### <a name="install_entry"></a>`install_entry`
+
+Data type: `Optional[Systemd::Unit::Install]`
+
+key value pairs for [Install] section of the unit file.
+
+Default value: ``undef``
 
 ### <a name="systemdmodules_load"></a>`systemd::modules_load`
 
@@ -1812,5 +2138,118 @@ Alias of
 
 ```puppet
 Pattern[/^[a-zA-Z0-9:\-_.\\@]+\.(service|socket|device|mount|automount|swap|target|path|timer|slice|scope)$/]
+```
+
+### <a name="systemdunitinstall"></a>`Systemd::Unit::Install`
+
+Possible keys for the [Install] section of a unit file
+
+* **See also**
+  * https://www.freedesktop.org/software/systemd/man/systemd.unit.html
+
+Alias of
+
+```puppet
+Struct[{
+    Optional['Alias']      => Variant[Enum[''],Systemd::Unit,Array[Variant[Enum[''],Systemd::Unit],1]],
+    Optional['WantedBy']   => Variant[Enum[''],Systemd::Unit,Array[Variant[Enum[''],Systemd::Unit],1]],
+    Optional['RequiredBy'] => Variant[Enum[''],Systemd::Unit,Array[Variant[Enum[''],Systemd::Unit],1]],
+    Optional['Also']       => Variant[Enum[''],Systemd::Unit,Array[Variant[Enum[''],Systemd::Unit],1]],
+  }]
+```
+
+### <a name="systemdunitservice"></a>`Systemd::Unit::Service`
+
+Possible keys for the [Service] section of a unit file
+
+* **See also**
+  * https://www.freedesktop.org/software/systemd/man/systemd.service.html
+  * https://www.freedesktop.org/software/systemd/man/systemd.exec.html
+
+Alias of
+
+```puppet
+Struct[{
+    Optional['Type']                      => Enum['simple', 'exec', 'forking', 'oneshot', 'dbus', 'notify', 'idle'],
+    Optional['ExitType']                  => Enum['main', 'cgroup'],
+    Optional['RemainAfterExit']           => Boolean,
+    Optional['GuessMainPID']              => Boolean,
+    Optional['PIDFile']                   => Stdlib::Unixpath,
+    Optional['BusName']                   => String[1],
+    Optional['ExecStart']                 => Variant[Systemd::Unit::Service::Exec,Array[Systemd::Unit::Service::Exec,1]],
+    Optional['ExecStartPre']              => Variant[Systemd::Unit::Service::Exec,Array[Systemd::Unit::Service::Exec,1]],
+    Optional['ExecStartPost']             => Variant[Systemd::Unit::Service::Exec,Array[Systemd::Unit::Service::Exec,1]],
+    Optional['ExecCondition']             => Variant[Systemd::Unit::Service::Exec,Array[Systemd::Unit::Service::Exec,1]],
+    Optional['ExecReload']                => Variant[Systemd::Unit::Service::Exec,Array[Systemd::Unit::Service::Exec,1]],
+    Optional['ExecStop']                  => Variant[Systemd::Unit::Service::Exec,Array[Systemd::Unit::Service::Exec,1]],
+    Optional['ExecStopPost']              => Variant[Systemd::Unit::Service::Exec,Array[Systemd::Unit::Service::Exec,1]],
+    Optional['RestartSec']                => String,
+    Optional['TimeoutStartSec']           => String,
+    Optional['TimeoutStopSec']            => String,
+    Optional['TimeoutAbortSec']           => String,
+    Optional['TimeoutAbortSec']           => String,
+    Optional['TimeoutSec']                => String,
+    Optional['TimeoutStartFailureMode']   => Enum['terminate', 'abort', 'kill'],
+    Optional['TimeoutStopFailureMode']    => Enum['terminate', 'abort', 'kill'],
+    Optional['RuntimeMaxSec']             => String,
+    Optional['RuntimeRandomizedExtraSec'] => String,
+    Optional['WatchdogSec']               => String,
+    Optional['Restart']                   => Enum['no', 'on-success', 'on-failure', 'on-abnormal', 'on-watchdog', 'on-abort', 'always'],
+    Optional['SuccessExitStatus']         => String,
+    Optional['RestartPreventExitStatus']  => String,
+    Optional['RestartForceExitStatus']    => String,
+    Optional['RootDirectoryStartOnly']    => Boolean,
+    Optional['NonBlocking']               => Boolean,
+    Optional['NotifyAccess']              => Enum['none', 'default', 'main', 'exec',  'all'],
+    Optional['OOMPolicy']                 => Enum['continue', 'stop','kill'],
+    Optional['OOMScoreAdjust']            => Integer[-1000,1000],
+    Optional['Environment']               => String,
+    Optional['EnvironmentFile']           => Variant[Stdlib::Unixpath,Pattern[/-\/.*/]],
+  }]
+```
+
+### <a name="systemdunitserviceexec"></a>`Systemd::Unit::Service::Exec`
+
+Possible strings for ExecStart, ExecStartPrep, ...
+
+* **See also**
+  * https://www.freedesktop.org/software/systemd/man/systemd.service.html
+  * https://www.freedesktop.org/software/systemd/man/systemd.exec.html
+
+Alias of
+
+```puppet
+Variant[Enum[''], Pattern[/^[@\-:]*(\+|!|!!)?[@\-:]*\/.*/], Pattern[/^[@\-:]*(\+|!|!!)?[@\-:]*[^\/]*(\s.*)?$/]]
+```
+
+### <a name="systemdunitunit"></a>`Systemd::Unit::Unit`
+
+Possible keys for the [Unit] section of a unit file
+
+* **See also**
+  * https://www.freedesktop.org/software/systemd/man/systemd.unit.html
+
+Alias of
+
+```puppet
+Struct[{
+    Optional['Description']              => Variant[String,Array[String,1]],
+    Optional['Documentation']            => Variant[String,Array[String,1]],
+    Optional['Wants']                    => Variant[Enum[''],Systemd::Unit,Array[Variant[Enum[''],Systemd::Unit],1]],
+    Optional['Requires']                 => Variant[Enum[''],Systemd::Unit,Array[Variant[Enum[''],Systemd::Unit],1]],
+    Optional['Requisite']                => Variant[Enum[''],Systemd::Unit,Array[Variant[Enum[''],Systemd::Unit],1]],
+    Optional['PartOf']                   => Variant[Enum[''],Systemd::Unit,Array[Variant[Enum[''],Systemd::Unit],1]],
+    Optional['Upholds']                  => Variant[Enum[''],Systemd::Unit,Array[Variant[Enum[''],Systemd::Unit],1]],
+    Optional['Conflicts']                => Variant[Enum[''],Systemd::Unit,Array[Variant[Enum[''],Systemd::Unit],1]],
+    Optional['Before']                   => Variant[Enum[''],Systemd::Unit,Array[Variant[Enum[''],Systemd::Unit],1]],
+    Optional['After']                    => Variant[Enum[''],Systemd::Unit,Array[Variant[Enum[''],Systemd::Unit],1]],
+    Optional['OnFailure']                => Variant[Enum[''],Systemd::Unit,Array[Variant[Enum[''],Systemd::Unit],1]],
+    Optional['OnSuccess']                => Variant[Enum[''],Systemd::Unit,Array[Variant[Enum[''],Systemd::Unit],1]],
+    # Conditions and Asserts
+    Optional['ConditionPathExists']      => Variant[Enum[''],Stdlib::Unixpath,Pattern[/^!.*$/],Array[Variant[Enum[''],Stdlib::Unixpath,Pattern[/^!.*$/]],1]],
+    Optional['ConditionPathIsDirectory'] => Variant[Enum[''],Stdlib::Unixpath,Pattern[/^!.*$/],Array[Variant[Enum[''],Stdlib::Unixpath,Pattern[/^!.*$/]],1]],
+    Optional['AssertPathExists']         => Variant[Enum[''],Stdlib::Unixpath,Pattern[/^!.*$/],Array[Variant[Enum[''],Stdlib::Unixpath,Pattern[/^!.*$/]],1]],
+    Optional['AssertPathIsDirectory']    => Variant[Enum[''],Stdlib::Unixpath,Pattern[/^!.*$/],Array[Variant[Enum[''],Stdlib::Unixpath,Pattern[/^!.*$/]],1]],
+  }]
 ```
 

--- a/manifests/manage_dropin.pp
+++ b/manifests/manage_dropin.pp
@@ -1,0 +1,66 @@
+# Creates a drop-in file for a systemd unit from a template
+#
+# @api public
+#
+# @see systemd.unit(5)
+#
+# @example drop in file to change Type and override ExecStart
+#   systemd::manage_dropin { 'myconf.conf':
+#     ensure        => present,
+#     unit          => 'myservice.service',
+#     service_entry => {
+#       'Type'      => 'oneshot',
+#       'ExecStart' => ['', '/usr/bin/doit.sh'],
+#     },
+#   }
+#
+# @param unit The unit to create a dropfile for
+# @param filename The target unit file to create. The filename of the drop in. The full path is determined using the path, unit and this filename.
+# @param ensure The state of this dropin file
+# @param path The main systemd configuration path
+# @param selinux_ignore_defaults If Puppet should ignore the default SELinux labels
+# @param owner The owner to set on the dropin file
+# @param group The group to set on the dropin file
+# @param mode The mode to set on the dropin file
+# @param show_diff Whether to show the diff when updating dropin file
+# @param notify_service Notify a service for the unit, if it exists
+# @param daemon_reload Call systemd::daemon_reload
+# @param unit_entry key value pairs for [Unit] section of the unit file
+# @param service_entry key value pairs for [Service] section of the unit file
+# @param install_entry key value pairs for [Install] section of the unit file
+#
+define systemd::manage_dropin (
+  Systemd::Unit                    $unit,
+  Systemd::Dropin                  $filename                = $name,
+  Enum['present', 'absent']        $ensure                  = 'present',
+  Stdlib::Absolutepath             $path                    = '/etc/systemd/system',
+  Boolean                          $selinux_ignore_defaults = false,
+  String                           $owner                   = 'root',
+  String                           $group                   = 'root',
+  Stdlib::Filemode                 $mode                    = '0444',
+  Boolean                          $show_diff               = true,
+  Boolean                          $notify_service          = false,
+  Boolean                          $daemon_reload           = true,
+  Optional[Systemd::Unit::Install] $install_entry           = undef,
+  Optional[Systemd::Unit::Unit]    $unit_entry              = undef,
+  Optional[Systemd::Unit::Service] $service_entry           = undef,
+) {
+  systemd::dropin_file { $name:
+    ensure                  => $ensure,
+    filename                => $filename,
+    unit                    => $unit,
+    path                    => $path,
+    selinux_ignore_defaults => $selinux_ignore_defaults,
+    owner                   => $owner,
+    group                   => $group,
+    mode                    => $mode,
+    show_diff               => $show_diff,
+    notify_service          => $notify_service,
+    daemon_reload           => $daemon_reload,
+    content                 => epp('systemd/unit_file.epp', {
+        'unit_entry'    => $unit_entry,
+        'service_entry' => $service_entry,
+        'install_entry' => $install_entry,
+    }),
+  }
+}

--- a/manifests/manage_unit.pp
+++ b/manifests/manage_unit.pp
@@ -1,0 +1,80 @@
+# @summary Generate unit file from template
+#
+# @api public
+#
+# @see systemd.unit(5)
+#
+# @example Generate a service
+#   systemd::manage_unit{ 'myrunner.service':
+#     $unit_entry    => {
+#       'Description' => 'My great service',
+#     },
+#     $service_entry => {
+#       'Type'       => 'oneshot',
+#       'ExecStart' => '/usr/bin/doit.sh',
+#     },
+#     $install_entry => {
+#       WantedBy => 'multi-user.target',
+#     },
+#   }
+# @param name [Pattern['^[^/]+\.(service|socket|device|mount|automount|swap|target|path|timer|slice|scope)$']]
+#   The target unit file to create
+#
+# @param ensure The state of the unit file to ensure
+# @param path The main systemd configuration path
+# @param owner The owner to set on the unit file
+# @param group The group to set on the unit file
+# @param mode The mode to set on the unit file
+# @param show_diff Whether to show the diff when updating unit file
+# @param enable If set, manage the unit enablement status
+# @param active If set, will manage the state of the unit
+# @param restart Specify a restart command manually. If left unspecified, a standard Puppet service restart happens
+# @param selinux_ignore_defaults
+#   maps to the same param on the file resource for the unit. false in the module because it's false in the file resource type
+# @param service_parameters
+#   hash that will be passed with the splat operator to the service resource
+# @param daemon_reload
+#   call `systemd::daemon-reload` to ensure that the modified unit file is loaded
+#
+# @param unit_entry  key value pairs for [Unit] section of the unit file.
+# @param service_entry key value pairs for [Service] section of the unit file.
+# @param install_entry key value pairs for [Install] section of the unit file.
+#
+define systemd::manage_unit (
+  Enum['present', 'absent']                $ensure                  = 'present',
+  Stdlib::Absolutepath                     $path                    = '/etc/systemd/system',
+  String                                   $owner                   = 'root',
+  String                                   $group                   = 'root',
+  Stdlib::Filemode                         $mode                    = '0444',
+  Boolean                                  $show_diff               = true,
+  Optional[Variant[Boolean, Enum['mask']]] $enable                  = undef,
+  Optional[Boolean]                        $active                  = undef,
+  Optional[String]                         $restart                 = undef,
+  Boolean                                  $selinux_ignore_defaults = false,
+  Hash[String[1], Any]                     $service_parameters      = {},
+  Boolean                                  $daemon_reload           = true,
+  Optional[Systemd::Unit::Install]         $install_entry           = undef,
+  Systemd::Unit::Unit                      $unit_entry,
+  Systemd::Unit::Service                   $service_entry,
+) {
+  assert_type(Systemd::Unit, $name)
+
+  systemd::unit_file { $name:
+    ensure                  => $ensure,
+    path                    => $path,
+    owner                   => $owner,
+    group                   => $group,
+    mode                    => $mode,
+    show_diff               => $show_diff,
+    enable                  => $enable,
+    active                  => $active,
+    selinux_ignore_defaults => $selinux_ignore_defaults,
+    service_parameters      => $service_parameters,
+    daemon_reload           => $daemon_reload,
+    content                 => epp('systemd/unit_file.epp', {
+        'unit_entry'    => $unit_entry,
+        'service_entry' => $service_entry,
+        'install_entry' => $install_entry,
+    }),
+  }
+}

--- a/spec/defines/manage_dropin_spec.rb
+++ b/spec/defines/manage_dropin_spec.rb
@@ -1,0 +1,60 @@
+# frozen_string_literal: true
+
+require 'spec_helper'
+
+describe 'systemd::manage_dropin' do
+  context 'supported operating systems' do
+    on_supported_os.each do |os, facts|
+      context "on #{os}" do
+        let(:facts) { facts }
+
+        let(:title) { 'foobar.conf' }
+
+        context 'drop file chaning Type and resetting ExecStart' do
+          let(:params) do
+            {
+              unit: 'special.service',
+              service_entry: {
+                Type:      'oneshot',
+                ExecStart: ['', '/usr/bin/doit.sh'],
+              },
+            }
+          end
+
+          it { is_expected.to compile.with_all_deps }
+          it { is_expected.to contain_systemd__dropin_file('foobar.conf') }
+
+          it {
+            is_expected.to contain_systemd__dropin_file('foobar.conf').
+              with_content(%r{^\[Service\]$})
+          }
+
+          it {
+            is_expected.to contain_systemd__dropin_file('foobar.conf').
+              without_content(%r{^\[Unit\]$})
+          }
+
+          it {
+            is_expected.to contain_systemd__dropin_file('foobar.conf').
+              without_content(%r{^\[Install\]$})
+          }
+
+          it {
+            is_expected.to contain_systemd__dropin_file('foobar.conf').
+              with_content(%r{^ExecStart=$})
+          }
+
+          it {
+            is_expected.to contain_systemd__dropin_file('foobar.conf').
+              with_content(%r{^ExecStart=/usr/bin/doit.sh$})
+          }
+
+          it {
+            is_expected.to contain_systemd__dropin_file('foobar.conf').
+              with_content(%r{^Type=oneshot$})
+          }
+        end
+      end
+    end
+  end
+end

--- a/spec/defines/manage_unit_spec.rb
+++ b/spec/defines/manage_unit_spec.rb
@@ -1,0 +1,65 @@
+# frozen_string_literal: true
+
+require 'spec_helper'
+
+describe 'systemd::manage_unit' do
+  context 'supported operating systems' do
+    on_supported_os.each do |os, facts|
+      context "on #{os}" do
+        let(:facts) { facts }
+
+        let(:title) { 'foobar.service' }
+
+        context 'with an arrayed description and simple parameters set' do
+          let(:params) do
+            {
+              unit_entry: {
+                Description: ['My great service', 'has two lines of description'],
+              },
+              service_entry: {
+                Type:      'oneshot',
+                ExecStart: '/usr/bin/doit.sh',
+              },
+              install_entry: {
+                WantedBy: 'multi-user.target',
+              }
+            }
+          end
+
+          it { is_expected.to compile.with_all_deps }
+          it { is_expected.to contain_systemd__unit_file('foobar.service') }
+
+          it {
+            is_expected.to contain_systemd__unit_file('foobar.service').
+              with_content(%r{^\[Unit\]$})
+          }
+
+          it {
+            is_expected.to contain_systemd__unit_file('foobar.service').
+              with_content(%r{^\[Service\]$})
+          }
+
+          it {
+            is_expected.to contain_systemd__unit_file('foobar.service').
+              with_content(%r{^\[Install\]$})
+          }
+
+          it {
+            is_expected.to contain_systemd__unit_file('foobar.service').
+              with_content(%r{^Description=My great service$})
+          }
+
+          it {
+            is_expected.to contain_systemd__unit_file('foobar.service').
+              with_content(%r{^Description=has two lines of description$})
+          }
+
+          it {
+            is_expected.to contain_systemd__unit_file('foobar.service').
+              with_content(%r{^Type=oneshot$})
+          }
+        end
+      end
+    end
+  end
+end

--- a/spec/type_aliases/systemd_unit_install_spec.rb
+++ b/spec/type_aliases/systemd_unit_install_spec.rb
@@ -1,0 +1,19 @@
+# frozen_string_literal: true
+
+require 'spec_helper'
+
+describe 'Systemd::Unit::Install' do
+  %w[Alias WantedBy RequiredBy Also].each do |depend|
+    context "with a key of #{depend} can have values of units" do
+      it { is_expected.to allow_value({ depend.to_s => 'foobar.service' }) }
+      it { is_expected.to allow_value({ depend.to_s => ['foobar.service'] }) }
+      it { is_expected.to allow_value({ depend.to_s => ['alpha.service', 'beta.service'] }) }
+      it { is_expected.to allow_value({ depend.to_s => '' }) }
+      it { is_expected.to allow_value({ depend.to_s => [''] }) }
+      it { is_expected.to allow_value({ depend.to_s => ['', 'foobar.service'] }) }
+    end
+  end
+
+  it { is_expected.not_to allow_value({ 'Also' => 'noextension' }) }
+  it { is_expected.not_to allow_value({ 'Also' => ['noextension'] }) }
+end

--- a/spec/type_aliases/systemd_unit_service_exec_spec.rb
+++ b/spec/type_aliases/systemd_unit_service_exec_spec.rb
@@ -1,0 +1,92 @@
+# frozen_string_literal: true
+
+require 'spec_helper'
+
+describe 'Systemd::Unit::Service::Exec' do
+  [
+    '',
+    '/usr/bin/doit.sh',
+    'doit.sh',
+    '/usr/bin/doit.sh and some arguments',
+    'doit.sh and some arguments',
+    '/usr/bin/doit.sh and some arguments/containing/a/slash',
+    'doit.sh and some arguments/containing/a/slash',
+
+    '@/usr/bin/doit.sh',
+    '@doit.sh',
+    '@/usr/bin/doit.sh and some arguments',
+    '@doit.sh and some arguments',
+
+    '-/usr/bin/doit.sh',
+    '-doit.sh',
+    '-/usr/bin/doit.sh and some arguments',
+    '-doit.sh and some arguments',
+
+    ':/usr/bin/doit.sh',
+    ':doit.sh',
+    ':/usr/bin/doit.sh and some arguments',
+    ':doit.sh and some arguments',
+
+    '+/usr/bin/doit.sh',
+    '+doit.sh',
+    '+/usr/bin/doit.sh and some arguments',
+    '+doit.sh and some arguments',
+
+    '!/usr/bin/doit.sh',
+    '!doit.sh',
+    '!/usr/bin/doit.sh and some arguments',
+    '!doit.sh and some arguments',
+
+    '!!/usr/bin/doit.sh',
+    '!!doit.sh',
+    '!!/usr/bin/doit.sh and some arguments',
+    '!!doit.sh and some arguments',
+
+    '@-:+/usr/bin/doit.sh',
+    '@-:+doit.sh',
+    '@-:+/usr/bin/doit.sh and some arguments',
+    '@-:+doit.sh and some arguments',
+
+    '@-:!/usr/bin/doit.sh',
+    '@-:!doit.sh',
+    '@-:!/usr/bin/doit.sh and some arguments',
+    '@-:!doit.sh and some arguments',
+
+    '@-:!!/usr/bin/doit.sh',
+    '@-:!!doit.sh',
+    '@-:!!/usr/bin/doit.sh and some arguments',
+    '@-:!!doit.sh and some arguments',
+
+    '-:+@/usr/bin/doit.sh',
+    '-:+@doit.sh',
+    '-:+@/usr/bin/doit.sh and some arguments',
+    '-:+@doit.sh and some arguments',
+
+    '-:!@/usr/bin/doit.sh',
+    '-:!@doit.sh',
+    '-:!@/usr/bin/doit.sh and some arguments',
+    '-:!@doit.sh and some arguments',
+
+    '-:!!@/usr/bin/doit.sh',
+    '-:!!@doit.sh',
+    '-:!!@/usr/bin/doit.sh and some arguments',
+    '-:!!@doit.sh and some arguments',
+
+  ].each do |exec|
+    context "with a value of #{exec} is permitted" do
+      it { is_expected.to allow_value(exec.to_s) }
+    end
+  end
+
+  [
+    'single/slash',
+    '+!/bin/doit.sh',
+    '+!!/bin/doit.sh',
+    '!+/bin/doit.sh',
+    '!!+/bin/doit.sh',
+  ].each do |exec|
+    context "with a value of #{exec} is not permitted" do
+      it { is_expected.not_to allow_value(exec.to_s) }
+    end
+  end
+end

--- a/spec/type_aliases/systemd_unit_service_spec.rb
+++ b/spec/type_aliases/systemd_unit_service_spec.rb
@@ -1,0 +1,23 @@
+# frozen_string_literal: true
+
+require 'spec_helper'
+
+describe 'Systemd::Unit::Service' do
+  %w[ExecStart ExecStartPre ExecStartPost ExecCondition ExecReload ExecStop ExecStopPost].each do |depend|
+    context "with a key of #{depend} can have values of commands" do
+      it { is_expected.to allow_value({ depend.to_s => '/usr/bin/doit.sh' }) }
+      it { is_expected.to allow_value({ depend.to_s => ['/usr/bin/doit.sh'] }) }
+      it { is_expected.to allow_value({ depend.to_s => ['-/usr/bin/doit.sh', ':/doit.sh', '+/doit.sh', '!/doit.sh', '!!/doit.sh'] }) }
+      it { is_expected.to allow_value({ depend.to_s => '' }) }
+      it { is_expected.to allow_value({ depend.to_s => [''] }) }
+      it { is_expected.to allow_value({ depend.to_s => ['', '/doit.sh'] }) }
+    end
+  end
+
+  it { is_expected.to allow_value({ 'ExecStart' => 'notabsolute.sh' }) }
+  it { is_expected.not_to allow_value({ 'ExecStart' => '*/wrongprefix.sh' }) }
+
+  it { is_expected.to allow_value({ 'EnvironmentFile' => '/etc/sysconfig/foo' }) }
+  it { is_expected.to allow_value({ 'EnvironmentFile' => '-/etc/sysconfig/foo' }) }
+  it { is_expected.not_to allow_value({ 'EnvironmentFile' => 'relative-path.sh' }) }
+end

--- a/spec/type_aliases/systemd_unit_unit_spec.rb
+++ b/spec/type_aliases/systemd_unit_unit_spec.rb
@@ -1,0 +1,45 @@
+# frozen_string_literal: true
+
+require 'spec_helper'
+
+describe 'Systemd::Unit::Unit' do
+  it { is_expected.to allow_value({ 'Description' => 'special' }) }
+  it { is_expected.to allow_value({ 'Description' => '' }) }
+  it { is_expected.to allow_value({ 'Description' => [''] }) }
+  it { is_expected.to allow_value({ 'Description' => %w[my special] }) }
+  it { is_expected.to allow_value({ 'Description' => ['', 'special'] }) }
+
+  it { is_expected.to allow_value({ 'Documentation' => 'special' }) }
+  it { is_expected.to allow_value({ 'Documentation' => '' }) }
+  it { is_expected.to allow_value({ 'Documentation' => [''] }) }
+  it { is_expected.to allow_value({ 'Documentation' => %w[my special] }) }
+  it { is_expected.to allow_value({ 'Documentation' => ['', 'special'] }) }
+
+  %w[Wants Requires Requisite Wants PartOf Upholds Conflicts Before After OnFailure OnSuccess].each do |depend|
+    context "with a key of #{depend} can have values of units" do
+      it { is_expected.to allow_value({ depend.to_s => 'foobar.service' }) }
+      it { is_expected.to allow_value({ depend.to_s => ['foobar.service'] }) }
+      it { is_expected.to allow_value({ depend.to_s => ['alpha.service', 'beta.service'] }) }
+      it { is_expected.to allow_value({ depend.to_s => '' }) }
+      it { is_expected.to allow_value({ depend.to_s => [''] }) }
+      it { is_expected.to allow_value({ depend.to_s => ['', 'foobar.service'] }) }
+    end
+  end
+
+  %w[ConditionPathExists ConditionPathIsDirectory AssertPathExists AssertPathIsDirectory].each do |assert|
+    context "with a key of #{assert} can have files or negated files" do
+      it { is_expected.to allow_value({ assert.to_s => '/my/existing/file' }) }
+      it { is_expected.to allow_value({ assert.to_s => '!/my/existing/file' }) }
+      it { is_expected.to allow_value({ assert.to_s => '' }) }
+      it { is_expected.to allow_value({ assert.to_s => ['', '/my/existing/file', '!/my/non/existing/file'] }) }
+    end
+  end
+
+  it { is_expected.not_to allow_value({ 'Description' => 10 }) }
+  it { is_expected.not_to allow_value({ 'Wants' => '/unitwith.service' }) }
+
+  it { is_expected.not_to allow_value({ 'Wants' => 'noextension' }) }
+  it { is_expected.not_to allow_value({ 'Wants' => ['noextension'] }) }
+  it { is_expected.not_to allow_value({ 'ConditionPathExists' => 'not/an/absolute/path' }) }
+  it { is_expected.not_to allow_value({ 'ConditionPathExists' => ['not/an/absolute/path'] }) }
+end

--- a/templates/unit_file.epp
+++ b/templates/unit_file.epp
@@ -7,7 +7,7 @@
 
 [Unit]
 <% $unit_entry.each | $_key, $_value | { -%>
-<% [$_value].flatten.each | $_subvalue | { -%>
+<% Array($_value, true).each | $_subvalue | { -%>
 <%= $_key %>=<%= $_subvalue %>
 <% } -%>
 <% } -%>
@@ -16,7 +16,7 @@
 
 [Service]
 <% $service_entry.each | $_key, $_value | { -%>
-<% [$_value].flatten.each | $_subvalue | { -%>
+<% Array($_value, true).each | $_subvalue | { -%>
 <%= $_key %>=<%= $_subvalue %>
 <% } -%>
 <% } -%>
@@ -25,7 +25,7 @@
 
 [Install]
 <% $install_entry.each | $_key, $_value | { -%>
-<% [$_value].flatten.each | $_subvalue | { -%>
+<% Array($_value, true).each | $_subvalue | { -%>
 <%= $_key %>=<%= $_subvalue %>
 <% } -%>
 <% } -%>

--- a/templates/unit_file.epp
+++ b/templates/unit_file.epp
@@ -1,0 +1,32 @@
+<%- |
+ Optional[Hash] $unit_entry,
+ Optional[Hash] $service_entry,
+ Optional[Hash] $install_entry,
+| -%>
+<% if $unit_entry { -%>
+
+[Unit]
+<% $unit_entry.each | $_key, $_value | { -%>
+<% [$_value].flatten.each | $_subvalue | { -%>
+<%= $_key %>=<%= $_subvalue %>
+<% } -%>
+<% } -%>
+<% } -%>
+<% if $service_entry { -%>
+
+[Service]
+<% $service_entry.each | $_key, $_value | { -%>
+<% [$_value].flatten.each | $_subvalue | { -%>
+<%= $_key %>=<%= $_subvalue %>
+<% } -%>
+<% } -%>
+<% } -%>
+<% if $install_entry { -%>
+
+[Install]
+<% $install_entry.each | $_key, $_value | { -%>
+<% [$_value].flatten.each | $_subvalue | { -%>
+<%= $_key %>=<%= $_subvalue %>
+<% } -%>
+<% } -%>
+<% } -%>

--- a/types/unit/install.pp
+++ b/types/unit/install.pp
@@ -1,0 +1,11 @@
+# @summary Possible keys for the [Install] section of a unit file
+# @see https://www.freedesktop.org/software/systemd/man/systemd.unit.html
+#
+type Systemd::Unit::Install = Struct[
+  {
+    Optional['Alias']      => Variant[Enum[''],Systemd::Unit,Array[Variant[Enum[''],Systemd::Unit],1]],
+    Optional['WantedBy']   => Variant[Enum[''],Systemd::Unit,Array[Variant[Enum[''],Systemd::Unit],1]],
+    Optional['RequiredBy'] => Variant[Enum[''],Systemd::Unit,Array[Variant[Enum[''],Systemd::Unit],1]],
+    Optional['Also']       => Variant[Enum[''],Systemd::Unit,Array[Variant[Enum[''],Systemd::Unit],1]],
+  }
+]

--- a/types/unit/service.pp
+++ b/types/unit/service.pp
@@ -1,0 +1,43 @@
+# @summary Possible keys for the [Service] section of a unit file
+# @see https://www.freedesktop.org/software/systemd/man/systemd.service.html
+# @see https://www.freedesktop.org/software/systemd/man/systemd.exec.html
+#
+type Systemd::Unit::Service = Struct[
+  {
+    Optional['Type']                      => Enum['simple', 'exec', 'forking', 'oneshot', 'dbus', 'notify', 'idle'],
+    Optional['ExitType']                  => Enum['main', 'cgroup'],
+    Optional['RemainAfterExit']           => Boolean,
+    Optional['GuessMainPID']              => Boolean,
+    Optional['PIDFile']                   => Stdlib::Unixpath,
+    Optional['BusName']                   => String[1],
+    Optional['ExecStart']                 => Variant[Systemd::Unit::Service::Exec,Array[Systemd::Unit::Service::Exec,1]],
+    Optional['ExecStartPre']              => Variant[Systemd::Unit::Service::Exec,Array[Systemd::Unit::Service::Exec,1]],
+    Optional['ExecStartPost']             => Variant[Systemd::Unit::Service::Exec,Array[Systemd::Unit::Service::Exec,1]],
+    Optional['ExecCondition']             => Variant[Systemd::Unit::Service::Exec,Array[Systemd::Unit::Service::Exec,1]],
+    Optional['ExecReload']                => Variant[Systemd::Unit::Service::Exec,Array[Systemd::Unit::Service::Exec,1]],
+    Optional['ExecStop']                  => Variant[Systemd::Unit::Service::Exec,Array[Systemd::Unit::Service::Exec,1]],
+    Optional['ExecStopPost']              => Variant[Systemd::Unit::Service::Exec,Array[Systemd::Unit::Service::Exec,1]],
+    Optional['RestartSec']                => String,
+    Optional['TimeoutStartSec']           => String,
+    Optional['TimeoutStopSec']            => String,
+    Optional['TimeoutAbortSec']           => String,
+    Optional['TimeoutAbortSec']           => String,
+    Optional['TimeoutSec']                => String,
+    Optional['TimeoutStartFailureMode']   => Enum['terminate', 'abort', 'kill'],
+    Optional['TimeoutStopFailureMode']    => Enum['terminate', 'abort', 'kill'],
+    Optional['RuntimeMaxSec']             => String,
+    Optional['RuntimeRandomizedExtraSec'] => String,
+    Optional['WatchdogSec']               => String,
+    Optional['Restart']                   => Enum['no', 'on-success', 'on-failure', 'on-abnormal', 'on-watchdog', 'on-abort', 'always'],
+    Optional['SuccessExitStatus']         => String,
+    Optional['RestartPreventExitStatus']  => String,
+    Optional['RestartForceExitStatus']    => String,
+    Optional['RootDirectoryStartOnly']    => Boolean,
+    Optional['NonBlocking']               => Boolean,
+    Optional['NotifyAccess']              => Enum['none', 'default', 'main', 'exec',  'all'],
+    Optional['OOMPolicy']                 => Enum['continue', 'stop','kill'],
+    Optional['OOMScoreAdjust']            => Integer[-1000,1000],
+    Optional['Environment']               => String,
+    Optional['EnvironmentFile']           => Variant[Stdlib::Unixpath,Pattern[/-\/.*/]],
+  }
+]

--- a/types/unit/service/exec.pp
+++ b/types/unit/service/exec.pp
@@ -1,0 +1,12 @@
+# @summary Possible strings for ExecStart, ExecStartPrep, ...
+# @see https://www.freedesktop.org/software/systemd/man/systemd.service.html
+# @see https://www.freedesktop.org/software/systemd/man/systemd.exec.html
+#
+type Systemd::Unit::Service::Exec = Variant[
+  # Can be an empty string
+  Enum[''],
+  # Can be an optional prefix and absolute path
+  Pattern[/^[@\-:]*(\+|!|!!)?[@\-:]*\/.*/],
+  # Can be an optional prefix and a name containing no slashes
+  Pattern[/^[@\-:]*(\+|!|!!)?[@\-:]*[^\/]*(\s.*)?$/]
+]

--- a/types/unit/unit.pp
+++ b/types/unit/unit.pp
@@ -1,0 +1,24 @@
+# @summary Possible keys for the [Unit] section of a unit file
+# @see https://www.freedesktop.org/software/systemd/man/systemd.unit.html
+#
+type Systemd::Unit::Unit = Struct[
+  {
+    Optional['Description']              => Variant[String,Array[String,1]],
+    Optional['Documentation']            => Variant[String,Array[String,1]],
+    Optional['Wants']                    => Variant[Enum[''],Systemd::Unit,Array[Variant[Enum[''],Systemd::Unit],1]],
+    Optional['Requires']                 => Variant[Enum[''],Systemd::Unit,Array[Variant[Enum[''],Systemd::Unit],1]],
+    Optional['Requisite']                => Variant[Enum[''],Systemd::Unit,Array[Variant[Enum[''],Systemd::Unit],1]],
+    Optional['PartOf']                   => Variant[Enum[''],Systemd::Unit,Array[Variant[Enum[''],Systemd::Unit],1]],
+    Optional['Upholds']                  => Variant[Enum[''],Systemd::Unit,Array[Variant[Enum[''],Systemd::Unit],1]],
+    Optional['Conflicts']                => Variant[Enum[''],Systemd::Unit,Array[Variant[Enum[''],Systemd::Unit],1]],
+    Optional['Before']                   => Variant[Enum[''],Systemd::Unit,Array[Variant[Enum[''],Systemd::Unit],1]],
+    Optional['After']                    => Variant[Enum[''],Systemd::Unit,Array[Variant[Enum[''],Systemd::Unit],1]],
+    Optional['OnFailure']                => Variant[Enum[''],Systemd::Unit,Array[Variant[Enum[''],Systemd::Unit],1]],
+    Optional['OnSuccess']                => Variant[Enum[''],Systemd::Unit,Array[Variant[Enum[''],Systemd::Unit],1]],
+    # Conditions and Asserts
+    Optional['ConditionPathExists']      => Variant[Enum[''],Stdlib::Unixpath,Pattern[/^!.*$/],Array[Variant[Enum[''],Stdlib::Unixpath,Pattern[/^!.*$/]],1]],
+    Optional['ConditionPathIsDirectory'] => Variant[Enum[''],Stdlib::Unixpath,Pattern[/^!.*$/],Array[Variant[Enum[''],Stdlib::Unixpath,Pattern[/^!.*$/]],1]],
+    Optional['AssertPathExists']         => Variant[Enum[''],Stdlib::Unixpath,Pattern[/^!.*$/],Array[Variant[Enum[''],Stdlib::Unixpath,Pattern[/^!.*$/]],1]],
+    Optional['AssertPathIsDirectory']    => Variant[Enum[''],Stdlib::Unixpath,Pattern[/^!.*$/],Array[Variant[Enum[''],Stdlib::Unixpath,Pattern[/^!.*$/]],1]],
+  }
+]


### PR DESCRIPTION
#### Pull Request (PR) description

A new type is added to create a service unit file from a template and then manage the resulting service.

Example
```puppet
systemd::manage_unit { 'myrunner.service':
  $unit_entry           => {
    'Description' => ['My great service', 'has two lines of description'],
  },
  $service_entry        => {
    'Type'        => 'oneshot',
    'ExecStart'   => '/usr/bin/doit.sh',
  },
  $install_entry        => {
    'WantedBy'      => 'multi-user.target',
  },
}
```

will generate and manage a new systemd unit from a template.

Similarly to create drop in files from the same template:

```puppet
systemd::manage_dropin {'myconf.conf':
  ensure        => present,
  unit          => 'myservice.service',
  service_entry => {
    'Type'      => 'oneshot',
    'ExecStart' => ['', '/usr/bin/doit.sh'],
  }
}
```
Not every systemd directive has been added but a healthy set has and subsequents can be added as required.

https://www.freedesktop.org/software/systemd/man/systemd.directives.html
