### PR TITLE
Make Systemd::Unit type stricter

### DIFF
--- a/REFERENCE.md
+++ b/REFERENCE.md
@@ -58,7 +58,7 @@
 * [`Systemd::MachineInfoSettings`](#systemdmachineinfosettings): Matches Systemd machine-info (hostnamectl) file Struct
 * [`Systemd::OomdSettings`](#systemdoomdsettings): Configurations for oomd.conf
 * [`Systemd::ServiceLimits`](#systemdservicelimits): Matches Systemd Service Limit Struct
-* [`Systemd::Unit`](#systemdunit): custom datatype that validates different filenames for systemd units
+* [`Systemd::Unit`](#systemdunit): custom datatype that validates different filenames for systemd units and unit templates
 
 ## Classes
 
@@ -1803,11 +1803,14 @@ Struct[{
 
 ### <a name="systemdunit"></a>`Systemd::Unit`
 
-custom datatype that validates different filenames for systemd units
+custom datatype that validates different filenames for systemd units and unit templates
+
+* **See also**
+  * https://www.freedesktop.org/software/systemd/man/systemd.unit.html
 
 Alias of
 
 ```puppet
-Pattern['^[^/]+\.(service|socket|device|mount|automount|swap|target|path|timer|slice|scope)$']
+Pattern[/^[[a-z][A-Z][0-9]:\-_.\\@]+\.(service|socket|device|mount|automount|swap|target|path|timer|slice|scope)$/]
 ```
 

--- a/REFERENCE.md
+++ b/REFERENCE.md
@@ -1811,6 +1811,6 @@ custom datatype that validates different filenames for systemd units and unit te
 Alias of
 
 ```puppet
-Pattern[/^[[a-z][A-Z][0-9]:\-_.\\@]+\.(service|socket|device|mount|automount|swap|target|path|timer|slice|scope)$/]
+Pattern[/^[a-zA-Z0-9:\-_.\\@]+\.(service|socket|device|mount|automount|swap|target|path|timer|slice|scope)$/]
 ```
 

--- a/spec/type_aliases/unit_spec.rb
+++ b/spec/type_aliases/unit_spec.rb
@@ -1,0 +1,32 @@
+# frozen_string_literal: true
+
+require 'spec_helper'
+
+describe 'Systemd::Unit' do
+  context 'with a permitted unit name' do
+    [
+      'foo.service',
+      'foo.socket',
+      'atemplate@.service',
+      'atemplate@instance.service',
+      'backward\slash.swap',
+      'extra.dot.scope',
+      'a:colon.path',
+      'an_underscore.device',
+      'a-dash.slice',
+    ].each do |unit|
+      it { is_expected.to allow_value(unit.to_s) }
+    end
+  end
+
+  context 'with a illegal unit name' do
+    [
+      'a space.service',
+      'noending',
+      'wrong.ending',
+      'forward/slash.unit',
+    ].each do |unit|
+      it { is_expected.not_to allow_value(unit.to_s) }
+    end
+  end
+end

--- a/types/unit.pp
+++ b/types/unit.pp
@@ -1,3 +1,3 @@
 # @summary custom datatype that validates different filenames for systemd units and unit templates
 # @see https://www.freedesktop.org/software/systemd/man/systemd.unit.html
-type Systemd::Unit = Pattern[/^[[a-z][A-Z][0-9]:\-_.\\@]+\.(service|socket|device|mount|automount|swap|target|path|timer|slice|scope)$/]
+type Systemd::Unit = Pattern[/^[a-zA-Z0-9:\-_.\\@]+\.(service|socket|device|mount|automount|swap|target|path|timer|slice|scope)$/]

--- a/types/unit.pp
+++ b/types/unit.pp
@@ -1,2 +1,3 @@
-# @summary custom datatype that validates different filenames for systemd units
-type Systemd::Unit = Pattern['^[^/]+\.(service|socket|device|mount|automount|swap|target|path|timer|slice|scope)$']
+# @summary custom datatype that validates different filenames for systemd units and unit templates
+# @see https://www.freedesktop.org/software/systemd/man/systemd.unit.html
+type Systemd::Unit = Pattern[/^[[a-z][A-Z][0-9]:\-_.\\@]+\.(service|socket|device|mount|automount|swap|target|path|timer|slice|scope)$/]


### PR DESCRIPTION
#### Pull Request (PR) description

Previously lots of unit names like

```
this is a service with spaces in.service
```
were permitted for instance.

From systemd.unit

> Valid unit names consist of a "name prefix" and a dot and a suffix specifying the unit type. The "unit prefix" must consist of one or more valid characters (ASCII letters, digits, ":", "-", "_", ".", and "\"). The total length of the unit name including the suffix must not exceed 256 characters. The type suffix must be one of ".service", ".socket", ".device", ".mount", ".automount", ".swap", ".target", ".path", ".timer", ".slice", or ".scope".

in addition we allow `@` to cover the case of template or template instance.

