### PR TITLE
resolved: `onlyif` snippet requires shell support

### DIFF
--- a/REFERENCE.md
+++ b/REFERENCE.md
@@ -192,7 +192,7 @@ Data type: `Enum['stopped','running']`
 
 The state that the ``resolved`` service should be in. When migrating from 'running' to
 'stopped' an attempt will be made to restore a working `/etc/resolv.conf` using
-`/run/systemd/resolved/resolv.conf`.
+`/run/systemd/resolve/resolv.conf`.
 
 Default value: `'running'`
 

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -27,7 +27,7 @@
 # @param resolved_ensure
 #   The state that the ``resolved`` service should be in. When migrating from 'running' to
 #   'stopped' an attempt will be made to restore a working `/etc/resolv.conf` using
-#   `/run/systemd/resolved/resolv.conf`.
+#   `/run/systemd/resolve/resolv.conf`.
 #
 # @param resolved_package
 #   The name of a systemd sub package needed for systemd-resolved if one needs to be installed.

--- a/manifests/resolved.pp
+++ b/manifests/resolved.pp
@@ -87,9 +87,10 @@ class systemd::resolved (
       # /etc/resolv.conf to something that might actually work on
       # reboot.
       exec { 'restore_resolv.conf_if_possible':
-        command => 'cp --remove-destination -f /run/systemd/resolve/resolv.conf /etc/resolv.conf',
-        onlyif  => 'l="$(readlink /etc/resolv.conf)"; test "$l" = "/run/systemd/resolve/resolv.conf" || test "$l" = "/run/systemd/resolve/stub-resolv.conf',
-        path    => $facts['path'],
+        command  => 'cp --remove-destination -f /run/systemd/resolve/resolv.conf /etc/resolv.conf',
+        onlyif   => 'l="$(readlink /etc/resolv.conf)"; test "$l" = "/run/systemd/resolve/resolv.conf" || test "$l" = "/run/systemd/resolve/stub-resolv.conf',
+        path     => $facts['path'],
+        provider => 'shell',
       }
     }
   }


### PR DESCRIPTION
Fixes a problem (I) introduced in https://github.com/voxpupuli/puppet-systemd/pull/276.