### PR TITLE
Unit_file: Add notify_service

### DIFF
--- a/spec/defines/unit_file_spec.rb
+++ b/spec/defines/unit_file_spec.rb
@@ -267,6 +267,16 @@ describe 'systemd::unit_file' do
             expect(subject).not_to create_systemd__daemon_reload(title)
           }
         end
+
+        context 'notify_service => false' do
+          let(:params) { { enable: true, notify_service: false } }
+
+          it do
+            is_expected.not_to contain_service(title).with_subscribes_to(
+              "File[/etc/systemd/system/#{title}]"
+            )
+          end
+        end
       end
     end
   end


### PR DESCRIPTION
#### Pull Request (PR) description
Hello,

I had add new parameters for Unit_file define, `notify_service`. This params I can use for disable the service notify. Very useful for not restart an in memory service for space or a new comment.

I've try to add spec but that not work. I've try something like that:
```ruby
context 'notify_service => false' do
  let(:params) { { enable: true, notify_service: false } }
  
  it do
    expect(subject).to contain_service(title).
      without_subscribes_to("File[/etc/systemd/system/#{title}]")
  end
end
```
or

```ruby
context 'notify_service => false' do
  let(:params) { { enable: true, notify_service: false } }
  
  it do
    expect(subject).to contain_file("/etc/systemd/system/#{title}").
      without_notifies("Service[#{title}]")
  end
end
```

Can you help me for this part ?

#### This Pull Request (PR) fixes the following issues
<!--
Replace this comment with the list of issues or n/a.
Use format:
Fixes #123
Fixes #124
-->

Regards,
