### PR TITLE
feat: manage timesyncd package on Debian >= 11 and Ubuntu >= 20.04

### DIFF
--- a/data/Debian-11.yaml
+++ b/data/Debian-11.yaml
@@ -6,3 +6,5 @@ systemd::accounting:
   DefaultBlockIOAccounting: 'yes'
   DefaultMemoryAccounting: 'yes'
   DefaultTasksAccounting: 'yes'
+
+systemd::timesyncd_package: 'systemd-timesyncd'

--- a/data/Ubuntu-20.04.yaml
+++ b/data/Ubuntu-20.04.yaml
@@ -6,3 +6,5 @@ systemd::accounting:
   DefaultBlockIOAccounting: 'yes'
   DefaultMemoryAccounting: 'yes'
   DefaultTasksAccounting: 'yes'
+
+systemd::timesyncd_package: 'systemd-timesyncd'

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -86,6 +86,9 @@
 # @param timesyncd_ensure
 #   The state that the ``timesyncd`` service should be in
 #
+# @param timesyncd_package
+#   Name of the package required for systemd-timesyncd, if any
+#
 # @param ntp_server
 #   comma separated list of ntp servers, will be combined with interface specific
 #   addresses from systemd-networkd. requires puppetlabs-inifile
@@ -200,6 +203,7 @@ class systemd (
   Enum['stopped','running']                           $networkd_ensure = 'running',
   Boolean                                             $manage_timesyncd = false,
   Enum['stopped','running']                           $timesyncd_ensure = 'running',
+  Optional[String[1]]                                 $timesyncd_package = undef,
   Optional[Variant[Array,String]]                     $ntp_server = undef,
   Optional[Variant[Array,String]]                     $fallback_ntp_server = undef,
   Boolean                                             $manage_accounting = false,

--- a/manifests/install.pp
+++ b/manifests/install.pp
@@ -7,4 +7,10 @@ class systemd::install {
       ensure => present,
     }
   }
+
+  if $systemd::manage_timesyncd and $systemd::timesyncd_package {
+    package { $systemd::timesyncd_package:
+      ensure => present,
+    }
+  }
 }

--- a/spec/classes/init_spec.rb
+++ b/spec/classes/init_spec.rb
@@ -17,6 +17,7 @@ describe 'systemd' do
         it { is_expected.not_to create_service('systemd-resolved') }
         it { is_expected.not_to create_service('systemd-networkd') }
         it { is_expected.not_to create_service('systemd-timesyncd') }
+        it { is_expected.not_to contain_package('systemd-timesyncd') }
         it { is_expected.not_to contain_package('systemd-resolved') }
         it { is_expected.not_to contain_class('systemd::coredump') }
         it { is_expected.not_to contain_class('systemd::oomd') }
@@ -263,6 +264,12 @@ describe 'systemd' do
           it { is_expected.not_to create_service('systemd-resolved').with_enable(true) }
           it { is_expected.not_to create_service('systemd-networkd').with_ensure('running') }
           it { is_expected.not_to create_service('systemd-networkd').with_enable(true) }
+
+          if (facts[:os]['name'] == 'Ubuntu' && Puppet::Util::Package.versioncmp(facts[:os]['release']['full'], '20.04') >= 0) || (facts[:os]['name'] == 'Debian' && Puppet::Util::Package.versioncmp(facts[:os]['release']['major'], '11') >= 0)
+            it { is_expected.to contain_package('systemd-timesyncd') }
+          else
+            it { is_expected.not_to contain_package('systemd-timesyncd') }
+          end
         end
 
         context 'when enabling timesyncd with NTP values (string)' do


### PR DESCRIPTION
Fixes #294 
