### PR TITLE
Remove debian 8 support

### DIFF
--- a/data/Debian-8.yaml
+++ b/data/Debian-8.yaml
@@ -1,5 +1,0 @@
----
-systemd::accounting:
-  DefaultCPUAccounting: 'yes'
-  DefaultBlockIOAccounting: 'yes'
-  DefaultMemoryAccounting: 'yes'

--- a/manifests/timesyncd.pp
+++ b/manifests/timesyncd.pp
@@ -37,17 +37,10 @@ class systemd::timesyncd (
     } else {
       $_ntp_server = join($ntp_server, ' ')
     }
-    $setting = $facts['os']['family'] ? {
-      'Debian' => $facts['os']['release']['major'] ? {
-        '8'     => 'Servers',
-        default => 'NTP',
-      },
-      default  => 'NTP',
-    }
     ini_setting { 'ntp_server':
       ensure  => 'present',
       value   => $_ntp_server,
-      setting => $setting,
+      setting => 'NTP',
       section => 'Time',
       path    => '/etc/systemd/timesyncd.conf',
       notify  => Service['systemd-timesyncd'],

--- a/metadata.json
+++ b/metadata.json
@@ -21,7 +21,6 @@
     {
       "operatingsystem": "Debian",
       "operatingsystemrelease": [
-        "8",
         "9",
         "10",
         "11"


### PR DESCRIPTION
#### Pull Request (PR) description

Debian 8 was end of life 2020-06-30

https://wiki.debian.org/DebianReleases

more over acceptance jobs now fail with:

```json
{"stream":"\u001b[91mW: GPG error: http://deb.debian.org/ jessie-updates InRelease: The following signatures were invalid: KEYEXPIRED 1668891673\nW: GPG error: http://deb.debian.org/ jessie Release: The following signatures were invalid: KEYEXPIRED 1668891673\n\u001b[0m"}

```
