### PR TITLE
Add restart_service parameter on service_limits for compatibility

### DIFF
--- a/REFERENCE.md
+++ b/REFERENCE.md
@@ -1273,6 +1273,7 @@ The following parameters are available in the `systemd::service_limits` defined 
 * [`selinux_ignore_defaults`](#-systemd--service_limits--selinux_ignore_defaults)
 * [`limits`](#-systemd--service_limits--limits)
 * [`source`](#-systemd--service_limits--source)
+* [`restart_service`](#-systemd--service_limits--restart_service)
 
 ##### <a name="-systemd--service_limits--name"></a>`name`
 
@@ -1323,6 +1324,14 @@ A ``File`` resource compatible ``source``
 * Mutually exclusive with ``$limits``
 
 Default value: `undef`
+
+##### <a name="-systemd--service_limits--restart_service"></a>`restart_service`
+
+Data type: `Boolean`
+
+Unused parameter for compatibility with older versions. Will fail if true is passed in.
+
+Default value: `false`
 
 ### <a name="systemd--timer"></a>`systemd::timer`
 
@@ -1643,8 +1652,6 @@ The following parameters are available in the `systemd::unit_file` defined type:
 * [`enable`](#-systemd--unit_file--enable)
 * [`active`](#-systemd--unit_file--active)
 * [`restart`](#-systemd--unit_file--restart)
-* [`hasrestart`](#-systemd--unit_file--hasrestart)
-* [`hasstatus`](#-systemd--unit_file--hasstatus)
 * [`selinux_ignore_defaults`](#-systemd--unit_file--selinux_ignore_defaults)
 * [`service_parameters`](#-systemd--unit_file--service_parameters)
 * [`daemon_reload`](#-systemd--unit_file--daemon_reload)
@@ -1754,22 +1761,6 @@ Default value: `undef`
 Data type: `Optional[String]`
 
 Specify a restart command manually. If left unspecified, a standard Puppet service restart happens.
-
-Default value: `undef`
-
-##### <a name="-systemd--unit_file--hasrestart"></a>`hasrestart`
-
-Data type: `Optional[Boolean]`
-
-maps to the same param on the service resource. Optional in the module because it's optional in the service resource type. This param is deprecated. Set it via $service_parameters.
-
-Default value: `undef`
-
-##### <a name="-systemd--unit_file--hasstatus"></a>`hasstatus`
-
-Data type: `Optional[Boolean]`
-
-maps to the same param on the service resource. true in the module because it's true in the service resource type. This param is deprecated. Set it via $service_parameters.
 
 Default value: `undef`
 

--- a/manifests/service_limits.pp
+++ b/manifests/service_limits.pp
@@ -26,13 +26,21 @@
 #
 #   * Mutually exclusive with ``$limits``
 #
+# @param restart_service
+#   Unused parameter for compatibility with older versions. Will fail if true is passed in.
+#
 define systemd::service_limits (
   Enum['present', 'absent', 'file'] $ensure                  = 'present',
   Stdlib::Absolutepath              $path                    = '/etc/systemd/system',
   Boolean                           $selinux_ignore_defaults = false,
   Optional[Systemd::ServiceLimits]  $limits                  = undef,
   Optional[String]                  $source                  = undef,
+  Boolean                           $restart_service         = false,
 ) {
+  if $restart_service {
+    fail('The restart_service parameter is deprecated and only false is a valid value')
+  }
+
   include systemd
 
   if $name !~ Pattern['^.+\.(service|socket|mount|swap)$'] {


### PR DESCRIPTION
In 8a9e03a4d6a58a5a5083d7ead60dcbc87f727d2f the parameter was removed, but this makes it very hard for modules to be compatible with both < 4 and >= 4. Requiring >= 4 will be painful, so this adds the parameter again but only accepts the parameter false.

A concrete example is the puppet-redis module which sets restart_service to false to prevent a restart. This would be compatible with both the old and new behavior, making upgrades smoother.