### PR TITLE
systemd::timer: fix before's argument to use the proper syntax

### DIFF
--- a/manifests/timer.pp
+++ b/manifests/timer.pp
@@ -91,7 +91,7 @@ define systemd::timer (
       group         => $group,
       mode          => $mode,
       show_diff     => $show_diff,
-      before        => Systemd::Unit_File[$name],
+      before        => Systemd::Unit_file[$name],
       daemon_reload => $daemon_reload,
     }
   }


### PR DESCRIPTION
I was reading the code and vim wouldn't highlight that line properly...