### PR TITLE
Fix `manage_unit` example in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -65,14 +65,14 @@ Create a unit file from parameters
 
 ```puppet
 systemd::manage_unit { 'myrunner.service':
-  $unit_entry    => {
+  unit_entry    => {
     'Description' => 'My great service',
   },
-  $service_entry => {
+  service_entry => {
     'Type'       => 'oneshot',
     'ExecStart' => '/usr/bin/doit.sh',
   },
-  $install_entry => {
+  install_entry => {
     'WantedBy' => 'multi-user.target',
   },
   enable         => true,

--- a/README.md
+++ b/README.md
@@ -65,18 +65,18 @@ Create a unit file from parameters
 
 ```puppet
 systemd::manage_unit { 'myrunner.service':
-  unit_entry    => {
+  unit_entry      => {
     'Description' => 'My great service',
   },
-  service_entry => {
-    'Type'       => 'oneshot',
-    'ExecStart' => '/usr/bin/doit.sh',
+  service_entry   => {
+    'Type'        => 'oneshot',
+    'ExecStart'   => '/usr/bin/doit.sh',
   },
-  install_entry => {
-    'WantedBy' => 'multi-user.target',
+  install_entry   => {
+    'WantedBy'    => 'multi-user.target',
   },
-  enable         => true,
-  active         => true,
+  enable          => true,
+  active          => true,
 }
 ```
 


### PR DESCRIPTION
#### Pull Request (PR) description
A $ sign is not valid syntax in the hash definition. Removing it gives a valid manifest file.

#### This Pull Request (PR) fixes the following issues
Fixes #325 
