### PR TITLE
Add comment in manage_unit deployed files

### DIFF
--- a/spec/defines/manage_dropin_spec.rb
+++ b/spec/defines/manage_dropin_spec.rb
@@ -17,6 +17,9 @@ describe 'systemd::manage_dropin' do
             }
           end
 
+          it { is_expected.to compile.with_all_deps }
+          it { is_expected.to contain_systemd__dropin_file('foobar.conf').with_content(%r{^# Deployed with puppet$}) }
+
           context 'setting some parameters simply' do
             let(:params) do
               super().merge(

--- a/templates/unit_file.epp
+++ b/templates/unit_file.epp
@@ -19,6 +19,8 @@
 ]
 
 -%>
+# Deployed with puppet
+#
 <%-
 $_unit_sections.each | $_section | {
   $_values = getvar("${downcase($_section)}_entry")


### PR DESCRIPTION
#### Pull Request (PR) description

It's useful to see clearly see that files deployed with puppet are deployed with puppet.

Add a comment to top of files deployed by `systemd::manage_unit` and  `systemd::manage_dropin`.

e.g 
```puppet
systemd::manage_unit{'redis@.service':
  ensure          => present,
  unit_entry    => {
    'Description' => 'redis server instance on port %i',
   },
  service_entry => {
    'Type'      => 'simple',
    'User'      => 'redis',
    'Group'     => 'redis',
    'ExecStart' => '/usr/bin/redis-server /etc/redis/redis_%i.conf',
    'ExecStop'  => '/usr/bin/redis-cli -p %i shutdown',
    'PIDFile'   => '/run/redis/%i.pid',
  },
}
```
will now deploy `/etc/systemd/system/@redis@.service` with a first line of:

```
# Deployed with puppet
```
