### PR TITLE
Allow DefaultDependencies to be set in [Unit] section

### DIFF
--- a/REFERENCE.md
+++ b/REFERENCE.md
@@ -2249,6 +2249,7 @@ Alias of
 Struct[{
     Optional['Description']              => Variant[String,Array[String,1]],
     Optional['Documentation']            => Variant[String,Array[String,1]],
+    Optional['DefaultDependencies']      => Boolean,
     Optional['Wants']                    => Variant[Enum[''],Systemd::Unit,Array[Variant[Enum[''],Systemd::Unit],1]],
     Optional['Requires']                 => Variant[Enum[''],Systemd::Unit,Array[Variant[Enum[''],Systemd::Unit],1]],
     Optional['Requisite']                => Variant[Enum[''],Systemd::Unit,Array[Variant[Enum[''],Systemd::Unit],1]],

--- a/spec/defines/manage_dropin_spec.rb
+++ b/spec/defines/manage_dropin_spec.rb
@@ -17,6 +17,21 @@ describe 'systemd::manage_dropin' do
             }
           end
 
+          context 'setting some parameters simply' do
+            let(:params) do
+              super().merge(
+                unit_entry: {
+                  DefaultDependencies: true
+                }
+              )
+            end
+
+            it {
+              is_expected.to contain_systemd__dropin_file('foobar.conf').
+                with_content(%r{^DefaultDependencies=true$})
+            }
+          end
+
           context 'drop file chaning Type and resetting ExecStart' do
             let(:params) do
               super().merge(

--- a/spec/defines/manage_unit_spec.rb
+++ b/spec/defines/manage_unit_spec.rb
@@ -15,6 +15,7 @@ describe 'systemd::manage_unit' do
             {
               unit_entry: {
                 Description: ['My great service', 'has two lines of description'],
+                DefaultDependencies: true,
               },
               service_entry: {
                 Type:      'oneshot',
@@ -31,6 +32,7 @@ describe 'systemd::manage_unit' do
           it {
             is_expected.to contain_systemd__unit_file('foobar.service').
               with_content(%r{^\[Unit\]$}).
+              with_content(%r{^DefaultDependencies=true$}).
               with_content(%r{^\[Service\]$}).
               with_content(%r{^\[Install\]$}).
               with_content(%r{^Description=My great service$}).

--- a/spec/type_aliases/systemd_unit_unit_spec.rb
+++ b/spec/type_aliases/systemd_unit_unit_spec.rb
@@ -35,6 +35,16 @@ describe 'Systemd::Unit::Unit' do
     end
   end
 
+  # Booleans
+  %w[DefaultDependencies].each do |assert|
+    context "with a key of #{assert} can have values set to true" do
+      it { is_expected.to allow_value(assert.to_s => true) }
+      it { is_expected.to allow_value({ assert.to_s => false }) }
+    end
+  end
+
+  it { is_expected.not_to allow_value({ 'DefaultDependencies' => 'yes' }) }
+
   it { is_expected.not_to allow_value({ 'Description' => 10 }) }
   it { is_expected.not_to allow_value({ 'Wants' => '/unitwith.service' }) }
 

--- a/types/unit/unit.pp
+++ b/types/unit/unit.pp
@@ -5,6 +5,7 @@ type Systemd::Unit::Unit = Struct[
   {
     Optional['Description']              => Variant[String,Array[String,1]],
     Optional['Documentation']            => Variant[String,Array[String,1]],
+    Optional['DefaultDependencies']      => Boolean,
     Optional['Wants']                    => Variant[Enum[''],Systemd::Unit,Array[Variant[Enum[''],Systemd::Unit],1]],
     Optional['Requires']                 => Variant[Enum[''],Systemd::Unit,Array[Variant[Enum[''],Systemd::Unit],1]],
     Optional['Requisite']                => Variant[Enum[''],Systemd::Unit,Array[Variant[Enum[''],Systemd::Unit],1]],


### PR DESCRIPTION
#### Pull Request (PR) description

Allow `DefaultDependencies` to be specified as a `Boolean` in the `[Unit]` section of a templated unit or dropin file.

e.g.

```puppet
systemd::manage_unit{'my.service':
  ensure     => present,
  unit_entry => {
    'DefaultDependencies' => false,
  },
}
```

https://www.freedesktop.org/software/systemd/man/systemd.unit.html#DefaultDependencies=