### PR TITLE
Addition of timer directives to manage_unit and manage_dropin

### DIFF
--- a/REFERENCE.md
+++ b/REFERENCE.md
@@ -2232,7 +2232,21 @@ Alias of
 
 ```puppet
 Struct[{
-    Optional['OnCalendar'] => Variant[String,Array[String,1]],
+    Optional['OnActiveSec']        => Variant[Integer[0],String,Array[Variant[Integer[0],String]]],
+    Optional['OnBootSec']          => Variant[Integer[0],String,Array[Variant[Integer[0],String]]],
+    Optional['OnStartUpSec']       => Variant[Integer[0],String,Array[Variant[Integer[0],String]]],
+    Optional['OnUnitActiveSec']    => Variant[Integer[0],String,Array[Variant[Integer[0],String]]],
+    Optional['OnUnitInactiveSec']  => Variant[Integer[0],String,Array[Variant[Integer[0],String]]],
+    Optional['OnCalendar']         => Variant[Integer[0],String,Array[Variant[Integer[0],String]]],
+    Optional['AccuracySec']        => Variant[Integer[0],String],
+    Optional['RandomizedDelaySec'] => Variant[Integer[0],String],
+    Optional['FixedRandomDelay']   => Boolean,
+    Optional['OnClockChange']      => Boolean,
+    Optional['OnTimezoneChange']   => Boolean,
+    Optional['Unit']               => Systemd::Unit,
+    Optional['Persistent']         => Boolean,
+    Optional['WakeSystem']         => Boolean,
+    Optional['RemainAfterElapse']  => Boolean,
   }]
 ```
 

--- a/spec/defines/manage_unit_spec.rb
+++ b/spec/defines/manage_unit_spec.rb
@@ -56,7 +56,18 @@ describe 'systemd::manage_unit' do
                 Description: 'Winter is coming',
               },
               timer_entry: {
+                'OnActiveSec' => '5min',
+                'OnBootSec' => ['', '1min 5s'],
+                'OnStartUpSec' => 10,
+                'OnUnitActiveSec' => '5s',
+                'OnUnitInactiveSec' => ['', 10],
                 'OnCalendar' => 'soon',
+                'AccuracySec' => '24h',
+                'RandomizedDelaySec' => '4min 20s',
+                'FixedRandomDelay' => true,
+                'OnClockChange' => false,
+                'OnTimezoneChange' => true,
+                'Unit' => 'summer.service',
               }
             }
           end
@@ -65,7 +76,21 @@ describe 'systemd::manage_unit' do
 
           it {
             is_expected.to contain_systemd__unit_file('winter.timer').
-              with_content(%r{^OnCalendar=soon$})
+              with_content(%r{^\[Timer\]$}).
+              with_content(%r{^OnActiveSec=5min$}).
+              with_content(%r{^OnBootSec=$}).
+              with_content(%r{^OnBootSec=1min 5s$}).
+              with_content(%r{^OnStartUpSec=10$}).
+              with_content(%r{^OnUnitActiveSec=5s$}).
+              with_content(%r{^OnUnitInactiveSec=$}).
+              with_content(%r{^OnUnitInactiveSec=10$}).
+              with_content(%r{^OnCalendar=soon$}).
+              with_content(%r{^AccuracySec=24h$}).
+              with_content(%r{^RandomizedDelaySec=4min 20s$}).
+              with_content(%r{^FixedRandomDelay=true$}).
+              with_content(%r{^OnClockChange=false$}).
+              with_content(%r{^OnTimezoneChange=true$}).
+              with_content(%r{^Unit=summer.service$})
           }
         end
       end

--- a/spec/type_aliases/systemd_unit_timer_spec.rb
+++ b/spec/type_aliases/systemd_unit_timer_spec.rb
@@ -1,0 +1,47 @@
+# frozen_string_literal: true
+
+require 'spec_helper'
+
+describe 'Systemd::Unit::Timer' do
+  # permitted durations and as arrays as well
+  %w[OnActiveSec OnBootSec OnStartUpSec OnUnitActiveSec OnUnitInactiveSec].each do |assert|
+    context "with a key of #{assert} can have values of units" do
+      it { is_expected.to allow_value({ assert => '' }) }
+      it { is_expected.to allow_value({ assert => 10 }) }
+      it { is_expected.to allow_value({ assert => '5min' }) }
+      it { is_expected.to allow_value({ assert => ['', 5, '50s', '5h 30min'] }) }
+    end
+  end
+
+  %w[OnCalendar].each do |assert|
+    context "with a key of #{assert} can have values of units" do
+      it { is_expected.to allow_value({ assert => '' }) }
+      it { is_expected.to allow_value({ assert => '24hours' }) }
+      it { is_expected.to allow_value({ assert => 'daily' }) }
+      it { is_expected.to allow_value({ assert => '1min 30s' }) }
+      it { is_expected.to allow_value({ assert => ['', 'daily', '1min 30s'] }) }
+    end
+  end
+
+  # permitted single values
+  %w[AccuracySec RandomizedDelaySec].each do |assert|
+    context "with a key of #{assert} can have values of units" do
+      it { is_expected.to allow_value({ assert => '' }) }
+      it { is_expected.to allow_value({ assert => 10 }) }
+      it { is_expected.to allow_value({ assert => '24hours' }) }
+      it { is_expected.to allow_value({ assert => '1min 30s' }) }
+    end
+  end
+
+  # permitted booleans
+  %w[FixedRandomDelay OnClockChange OnTimezoneChange Persistent RemainAfterElapse].each do |assert|
+    context "with a key of #{assert} can have values of a time period" do
+      it { is_expected.to allow_value({ assert => false }) }
+      it { is_expected.to allow_value({ assert => true }) }
+      it { is_expected.not_to allow_value({ assert => 'yes' }) }
+    end
+  end
+
+  it { is_expected.to allow_value({ 'Unit' => 'my.service' }) }
+  it { is_expected.not_to allow_value({ 'Unit' => 'my' }) }
+end

--- a/types/unit/timer.pp
+++ b/types/unit/timer.pp
@@ -3,6 +3,20 @@
 #
 type Systemd::Unit::Timer = Struct[
   {
-    Optional['OnCalendar'] => Variant[String,Array[String,1]],
+    Optional['OnActiveSec']        => Variant[Integer[0],String,Array[Variant[Integer[0],String]]],
+    Optional['OnBootSec']          => Variant[Integer[0],String,Array[Variant[Integer[0],String]]],
+    Optional['OnStartUpSec']       => Variant[Integer[0],String,Array[Variant[Integer[0],String]]],
+    Optional['OnUnitActiveSec']    => Variant[Integer[0],String,Array[Variant[Integer[0],String]]],
+    Optional['OnUnitInactiveSec']  => Variant[Integer[0],String,Array[Variant[Integer[0],String]]],
+    Optional['OnCalendar']         => Variant[Integer[0],String,Array[Variant[Integer[0],String]]],
+    Optional['AccuracySec']        => Variant[Integer[0],String],
+    Optional['RandomizedDelaySec'] => Variant[Integer[0],String],
+    Optional['FixedRandomDelay']   => Boolean,
+    Optional['OnClockChange']      => Boolean,
+    Optional['OnTimezoneChange']   => Boolean,
+    Optional['Unit']               => Systemd::Unit,
+    Optional['Persistent']         => Boolean,
+    Optional['WakeSystem']         => Boolean,
+    Optional['RemainAfterElapse']  => Boolean,
   }
 ]


### PR DESCRIPTION
#### Pull Request (PR) description

The timer directives for unit files is now complete for options present in the man page of systemd-253.

For example:

```puppet
systemd::manage_unit{'my.timer':
  ensure => present,
  unit_entry => {
    'Description' => 'my timer',
  },
  timer_entry => {
    'Calendar' => 'daily',
    'AccuracySecs' => '1 hour',
  },
}
```

Previously only the 'Calendar' directive was available and this patch also includes a bug fix for that.

Previously

```
systemd::manage_dropin{'my.timer':
  ensure => present,
  unit => 'myunit.service',
  timer_entry => {
    'Calendar' => ['','daily'],
  },
}
```
with an empty resetting first `''` element was not permitted and now it is..
