### PR TITLE
Addition of path directives to manage_unit/dropin

### DIFF
--- a/REFERENCE.md
+++ b/REFERENCE.md
@@ -970,7 +970,7 @@ systemd::manage_unit { 'myrunner.service':
 ##### Genenerate a path unit
 
 ```puppet
-systemd::manage_init { 'passwd-mon.path':
+systemd::manage_unit { 'passwd-mon.path':
   ensure        => present,
   unit_entry      => {
     'Description' => 'Monitor the passwd file',

--- a/REFERENCE.md
+++ b/REFERENCE.md
@@ -62,6 +62,7 @@
 * [`Systemd::ServiceLimits`](#Systemd--ServiceLimits): Matches Systemd Service Limit Struct
 * [`Systemd::Unit`](#Systemd--Unit): custom datatype that validates different filenames for systemd units and unit templates
 * [`Systemd::Unit::Install`](#Systemd--Unit--Install): Possible keys for the [Install] section of a unit file
+* [`Systemd::Unit::Path`](#Systemd--Unit--Path): Possible keys for the [Path] section of a unit file
 * [`Systemd::Unit::Service`](#Systemd--Unit--Service): Possible keys for the [Service] section of a unit file
 * [`Systemd::Unit::Service::Exec`](#Systemd--Unit--Service--Exec): Possible strings for ExecStart, ExecStartPrep, ...
 * [`Systemd::Unit::Timer`](#Systemd--Unit--Timer): Possible keys for the [Timer] section of a unit file
@@ -781,6 +782,18 @@ systemd::manage_dropin { 'myconf.conf':
 }
 ```
 
+##### drop in file to change a path unit and override TriggerLimitBurst
+
+```puppet
+systemd::manage_dropin { 'triggerlimit.conf':
+  ensure     => present,
+  unit       => 'passwd.path',
+  path_entry => {
+    'TriggerLimitBurst' => 100,
+  },
+}
+```
+
 #### Parameters
 
 The following parameters are available in the `systemd::manage_dropin` defined type:
@@ -800,6 +813,7 @@ The following parameters are available in the `systemd::manage_dropin` defined t
 * [`service_entry`](#-systemd--manage_dropin--service_entry)
 * [`install_entry`](#-systemd--manage_dropin--install_entry)
 * [`timer_entry`](#-systemd--manage_dropin--timer_entry)
+* [`path_entry`](#-systemd--manage_dropin--path_entry)
 
 ##### <a name="-systemd--manage_dropin--unit"></a>`unit`
 
@@ -919,6 +933,14 @@ key value pairs for [Timer] section of the unit file
 
 Default value: `undef`
 
+##### <a name="-systemd--manage_dropin--path_entry"></a>`path_entry`
+
+Data type: `Optional[Systemd::Unit::Path]`
+
+key value pairs for [Path] section of the unit file
+
+Default value: `undef`
+
 ### <a name="systemd--manage_unit"></a>`systemd::manage_unit`
 
 Generate unit file from template
@@ -945,6 +967,24 @@ systemd::manage_unit { 'myrunner.service':
 }
 ```
 
+##### Genenerate a path unit
+
+```puppet
+systemd::manage_init { 'passwd-mon.path':
+  ensure        => present,
+  unit_entry      => {
+    'Description' => 'Monitor the passwd file',
+  },
+  path_entry    => {
+    'PathModified => '/etc/passwd',
+    'Unit'        => 'passwd-mon.service',
+  },
+  install_entry => {
+    'WantedBy'    => 'multi-user.target',
+  },
+}
+```
+
 #### Parameters
 
 The following parameters are available in the `systemd::manage_unit` defined type:
@@ -966,6 +1006,7 @@ The following parameters are available in the `systemd::manage_unit` defined typ
 * [`service_entry`](#-systemd--manage_unit--service_entry)
 * [`install_entry`](#-systemd--manage_unit--install_entry)
 * [`timer_entry`](#-systemd--manage_unit--timer_entry)
+* [`path_entry`](#-systemd--manage_unit--path_entry)
 
 ##### <a name="-systemd--manage_unit--name"></a>`name`
 
@@ -1096,6 +1137,14 @@ Default value: `undef`
 Data type: `Optional[Systemd::Unit::Timer]`
 
 key value pairs for [Timer] section of the unit file
+
+Default value: `undef`
+
+##### <a name="-systemd--manage_unit--path_entry"></a>`path_entry`
+
+Data type: `Optional[Systemd::Unit::Path]`
+
+key value pairs for [Path] section of the unit file.
 
 Default value: `undef`
 
@@ -2152,6 +2201,30 @@ Struct[{
     Optional['WantedBy']   => Variant[Enum[''],Systemd::Unit,Array[Variant[Enum[''],Systemd::Unit],1]],
     Optional['RequiredBy'] => Variant[Enum[''],Systemd::Unit,Array[Variant[Enum[''],Systemd::Unit],1]],
     Optional['Also']       => Variant[Enum[''],Systemd::Unit,Array[Variant[Enum[''],Systemd::Unit],1]],
+  }]
+```
+
+### <a name="Systemd--Unit--Path"></a>`Systemd::Unit::Path`
+
+Possible keys for the [Path] section of a unit file
+
+* **See also**
+  * https://www.freedesktop.org/software/systemd/man/systemd.path.html
+
+Alias of
+
+```puppet
+Struct[{
+    Optional['PathExists']              => Variant[Enum[''],Stdlib::Unixpath,Array[Variant[Enum[''],Stdlib::Unixpath],1]],
+    Optional['PathExistsGlob']          => Variant[Enum[''],Stdlib::Unixpath,Array[Variant[Enum[''],Stdlib::Unixpath],1]],
+    Optional['PathChanged']             => Variant[Enum[''],Stdlib::Unixpath,Array[Variant[Enum[''],Stdlib::Unixpath],1]],
+    Optional['PathModified']            => Variant[Enum[''],Stdlib::Unixpath,Array[Variant[Enum[''],Stdlib::Unixpath],1]],
+    Optional['DirectoryNotEmpty']       => Variant[Enum[''],Stdlib::Unixpath,Array[Variant[Enum[''],Stdlib::Unixpath],1]],
+    Optional['Unit']                    => Systemd::Unit,
+    Optional['MakeDirectory']           => Boolean,
+    Optional['DirectoryMode']           => Pattern[/\A[0-7]{1,4}\z/],
+    Optional['TriggerLimitIntervalSec'] => String,
+    Optional['TriggerLimitBurst']       => Integer[0],
   }]
 ```
 

--- a/manifests/manage_dropin.pp
+++ b/manifests/manage_dropin.pp
@@ -59,7 +59,7 @@ define systemd::manage_dropin (
   Optional[Systemd::Unit::Path]    $path_entry              = undef,
 ) {
   if $timer_entry and $unit !~ Pattern['^[^/]+\.timer'] {
-    fail("Systemd::Manage_unit[${name}]: timer_entry is only valid for timer units")
+    fail("Systemd::Manage_dropin[${name}]: for unit ${unit} timer_entry is only valid for timer units")
   }
 
   if $path_entry and $unit !~ Pattern['^[^/]+\.path'] {

--- a/manifests/manage_dropin.pp
+++ b/manifests/manage_dropin.pp
@@ -14,6 +14,15 @@
 #     },
 #   }
 #
+## @example drop in file to change a path unit and override TriggerLimitBurst
+#   systemd::manage_dropin { 'triggerlimit.conf':
+#     ensure     => present,
+#     unit       => 'passwd.path',
+#     path_entry => {
+#       'TriggerLimitBurst' => 100,
+#     },
+#   }
+#
 # @param unit The unit to create a dropfile for
 # @param filename The target unit file to create. The filename of the drop in. The full path is determined using the path, unit and this filename.
 # @param ensure The state of this dropin file
@@ -29,6 +38,7 @@
 # @param service_entry key value pairs for [Service] section of the unit file
 # @param install_entry key value pairs for [Install] section of the unit file
 # @param timer_entry key value pairs for [Timer] section of the unit file
+# @param path_entry key value pairs for [Path] section of the unit file
 #
 define systemd::manage_dropin (
   Systemd::Unit                    $unit,
@@ -46,9 +56,14 @@ define systemd::manage_dropin (
   Optional[Systemd::Unit::Unit]    $unit_entry              = undef,
   Optional[Systemd::Unit::Service] $service_entry           = undef,
   Optional[Systemd::Unit::Timer]   $timer_entry             = undef,
+  Optional[Systemd::Unit::Path]    $path_entry              = undef,
 ) {
   if $timer_entry and $unit !~ Pattern['^[^/]+\.timer'] {
     fail("Systemd::Manage_unit[${name}]: timer_entry is only valid for timer units")
+  }
+
+  if $path_entry and $unit !~ Pattern['^[^/]+\.path'] {
+    fail("Systemd::Manage_dropin[${name}]: for unit ${unit} path_entry is only valid for path units")
   }
 
   systemd::dropin_file { $name:
@@ -68,6 +83,7 @@ define systemd::manage_dropin (
         'service_entry' => $service_entry,
         'install_entry' => $install_entry,
         'timer_entry'   => $timer_entry,
+        'path_entry'    => $path_entry,
     }),
   }
 }

--- a/manifests/manage_unit.pp
+++ b/manifests/manage_unit.pp
@@ -19,7 +19,7 @@
 #   }
 #
 # @example Genenerate a path unit
-#   systemd::manage_init { 'passwd-mon.path':
+#   systemd::manage_unit { 'passwd-mon.path':
 #     ensure        => present,
 #     unit_entry      => {
 #       'Description' => 'Monitor the passwd file',

--- a/manifests/manage_unit.pp
+++ b/manifests/manage_unit.pp
@@ -17,6 +17,22 @@
 #       WantedBy => 'multi-user.target',
 #     },
 #   }
+#
+# @example Genenerate a path unit
+#   systemd::manage_init { 'passwd-mon.path':
+#     ensure        => present,
+#     unit_entry      => {
+#       'Description' => 'Monitor the passwd file',
+#     },
+#     path_entry    => {
+#       'PathModified => '/etc/passwd',
+#       'Unit'        => 'passwd-mon.service',
+#     },
+#     install_entry => {
+#       'WantedBy'    => 'multi-user.target',
+#     },
+#   }
+#
 # @param name [Pattern['^[^/]+\.(service|socket|device|mount|automount|swap|target|path|timer|slice|scope)$']]
 #   The target unit file to create
 #
@@ -40,6 +56,7 @@
 # @param service_entry key value pairs for [Service] section of the unit file.
 # @param install_entry key value pairs for [Install] section of the unit file.
 # @param timer_entry key value pairs for [Timer] section of the unit file
+# @param path_entry key value pairs for [Path] section of the unit file.
 #
 define systemd::manage_unit (
   Enum['present', 'absent']                $ensure                  = 'present',
@@ -58,11 +75,16 @@ define systemd::manage_unit (
   Systemd::Unit::Unit                      $unit_entry,
   Optional[Systemd::Unit::Service]         $service_entry           = undef,
   Optional[Systemd::Unit::Timer]           $timer_entry             = undef,
+  Optional[Systemd::Unit::Path]            $path_entry              = undef,
 ) {
   assert_type(Systemd::Unit, $name)
 
   if $timer_entry and $name !~ Pattern['^[^/]+\.timer'] {
     fail("Systemd::Manage_unit[${name}]: timer_entry is only valid for timer units")
+  }
+
+  if $path_entry and $name !~ Pattern['^[^/]+\.path'] {
+    fail("Systemd::Manage_unit[${name}]: path_entry is only valid for path units")
   }
 
   if $name =~ Pattern['^[^/]+\.service'] and !$service_entry {
@@ -86,6 +108,7 @@ define systemd::manage_unit (
         'service_entry' => $service_entry,
         'install_entry' => $install_entry,
         'timer_entry'   => $timer_entry,
+        'path_entry'    => $path_entry,
     }),
   }
 }

--- a/spec/defines/manage_dropin_spec.rb
+++ b/spec/defines/manage_dropin_spec.rb
@@ -28,35 +28,14 @@ describe 'systemd::manage_dropin' do
             end
 
             it { is_expected.to compile.with_all_deps }
-            it { is_expected.to contain_systemd__dropin_file('foobar.conf') }
 
             it {
               is_expected.to contain_systemd__dropin_file('foobar.conf').
-                with_content(%r{^\[Service\]$})
-            }
-
-            it {
-              is_expected.to contain_systemd__dropin_file('foobar.conf').
-                without_content(%r{^\[Unit\]$})
-            }
-
-            it {
-              is_expected.to contain_systemd__dropin_file('foobar.conf').
-                without_content(%r{^\[Install\]$})
-            }
-
-            it {
-              is_expected.to contain_systemd__dropin_file('foobar.conf').
-                with_content(%r{^ExecStart=$})
-            }
-
-            it {
-              is_expected.to contain_systemd__dropin_file('foobar.conf').
-                with_content(%r{^ExecStart=/usr/bin/doit.sh$})
-            }
-
-            it {
-              is_expected.to contain_systemd__dropin_file('foobar.conf').
+                with_content(%r{^\[Service\]$}).
+                without_content(%r{^\[Unit\]$}).
+                without_content(%r{^\[Install\]$}).
+                with_content(%r{^ExecStart=$}).
+                with_content(%r{^ExecStart=/usr/bin/doit.sh$}).
                 with_content(%r{^Type=oneshot$})
             }
           end

--- a/spec/defines/manage_dropin_spec.rb
+++ b/spec/defines/manage_dropin_spec.rb
@@ -92,6 +92,26 @@ describe 'systemd::manage_dropin' do
               with_content(%r{^OnCalendar=soon$})
           }
         end
+
+        context 'on a path unit' do
+          let(:params) do
+            {
+              unit: 'special.path',
+              path_entry: {
+                'PathExists' => '/etc/hosts',
+              }
+            }
+          end
+
+          it { is_expected.to compile.with_all_deps }
+
+          it {
+            is_expected.to contain_systemd__dropin_file('foobar.conf').
+              with_unit('special.path').
+              with_content(%r{^\[Path\]$}).
+              with_content(%r{^PathExists=/etc/hosts$})
+          }
+        end
       end
     end
   end

--- a/spec/type_aliases/systemd_unit_path_spec.rb
+++ b/spec/type_aliases/systemd_unit_path_spec.rb
@@ -1,0 +1,58 @@
+# frozen_string_literal: true
+
+require 'spec_helper'
+
+describe 'Systemd::Unit::Path' do
+  %w[PathExists PathExistsGlob PathChanged PathModified DirectoryNotEmpty].each do |assert|
+    context "with a key of #{assert} can have values of a path" do
+      it { is_expected.to allow_value({ assert => '' }) }
+      it { is_expected.to allow_value({ assert => '/etc/passwd' }) }
+      it { is_expected.to allow_value({ assert => '/etc/krb5.conf.d/*.conf' }) }
+      it { is_expected.to allow_value({ assert => ['', '/etc/group', '/etc/sssd/sssd.conf.d/*.conf'] }) }
+      it { is_expected.not_to allow_value({ assert => 'rc.d/rc.local' }) }
+      it { is_expected.not_to allow_value({ assert => ['', 'var/run'] }) }
+    end
+  end
+
+  %w[Unit].each do |assert|
+    context "with a key of #{assert} can have values of a unit name" do
+      it { is_expected.to allow_value({ assert => 'my.service' }) }
+      it { is_expected.not_to allow_value({ assert => 'yours' }) }
+    end
+  end
+
+  %w[MakeDirectory].each do |assert|
+    context "with a key of #{assert} can have values of a boolean" do
+      it { is_expected.to allow_value({ assert => false }) }
+      it { is_expected.to allow_value({ assert => true }) }
+      it { is_expected.not_to allow_value({ assert => 'yes' }) }
+    end
+  end
+
+  %w[DirectoryMode].each do |assert|
+    context "with a key of #{assert} can have values of a file permission" do
+      it { is_expected.to allow_value({ assert => '0755' }) }
+      it { is_expected.to allow_value({ assert => '700' }) }
+      it { is_expected.not_to allow_value({ assert => 0o755 }) }
+      it { is_expected.not_to allow_value({ assert => 755 }) }
+      it { is_expected.not_to allow_value({ assert => 'u+s,g-s' }) }
+    end
+  end
+
+  %w[TriggerLimitIntervalSec].each do |assert|
+    context "with a key of #{assert} can have value of a time period" do
+      it { is_expected.to allow_value({ assert => '' }) }   # ? Not sure actually
+      it { is_expected.to allow_value({ assert => '24hours' }) }
+      it { is_expected.to allow_value({ assert => '1min 30s' }) }
+      it { is_expected.not_to allow_value({ assert => ['', '1min 30s'] }) }
+    end
+  end
+
+  %w[TriggerLimitBurst].each do |assert|
+    context "with a key of #{assert} can have values of a count" do
+      it { is_expected.to allow_value({ assert => 0 }) }
+      it { is_expected.to allow_value({ assert => 10 }) }
+      it { is_expected.not_to allow_value({ assert => '5' }) }
+    end
+  end
+end

--- a/templates/unit_file.epp
+++ b/templates/unit_file.epp
@@ -3,6 +3,7 @@
  Optional[Hash] $service_entry,
  Optional[Hash] $install_entry,
  Optional[Hash] $timer_entry,
+ Optional[Hash] $path_entry,
 | -%>
 <% if $unit_entry { -%>
 
@@ -26,6 +27,15 @@
 
 [Timer]
 <% $timer_entry.each | $_key, $_value | { -%>
+<% Array($_value, true).each | $_subvalue | { -%>
+<%= $_key %>=<%= $_subvalue %>
+<% } -%>
+<% } -%>
+<% } -%>
+<% if $path_entry { -%>
+
+[Path]
+<% $path_entry.each | $_key, $_value | { -%>
 <% Array($_value, true).each | $_subvalue | { -%>
 <%= $_key %>=<%= $_subvalue %>
 <% } -%>

--- a/types/unit/path.pp
+++ b/types/unit/path.pp
@@ -1,0 +1,17 @@
+# @summary Possible keys for the [Path] section of a unit file
+# @see https://www.freedesktop.org/software/systemd/man/systemd.path.html
+#
+type Systemd::Unit::Path = Struct[
+  {
+    Optional['PathExists']              => Variant[Enum[''],Stdlib::Unixpath,Array[Variant[Enum[''],Stdlib::Unixpath],1]],
+    Optional['PathExistsGlob']          => Variant[Enum[''],Stdlib::Unixpath,Array[Variant[Enum[''],Stdlib::Unixpath],1]],
+    Optional['PathChanged']             => Variant[Enum[''],Stdlib::Unixpath,Array[Variant[Enum[''],Stdlib::Unixpath],1]],
+    Optional['PathModified']            => Variant[Enum[''],Stdlib::Unixpath,Array[Variant[Enum[''],Stdlib::Unixpath],1]],
+    Optional['DirectoryNotEmpty']       => Variant[Enum[''],Stdlib::Unixpath,Array[Variant[Enum[''],Stdlib::Unixpath],1]],
+    Optional['Unit']                    => Systemd::Unit,
+    Optional['MakeDirectory']           => Boolean,
+    Optional['DirectoryMode']           => Pattern[/\A[0-7]{1,4}\z/],
+    Optional['TriggerLimitIntervalSec'] => String,
+    Optional['TriggerLimitBurst']       => Integer[0],
+  }
+]


### PR DESCRIPTION
#### Pull Request (PR) description
The path directives for unit files is now complete for options present in the man page
of systemd-253.

The parameter `path_entry` can now be specified for `systemd::manage_unit` or
`systemd::manage_dropin`.

For example:

```puppet
systemd::manage_unit{'etc-passwd.path':
  ensure     => present,
  unit_entry => {
    'Description' => 'Monitor /etc/passwd',
  },
  path_entry => {
    'PathChanged' => '/etc/passwd',
    'Unit'        => 'etc-passwd-updates.service',
  },
}
```

or

```puppet
systemd::manage_dropin{'trigger-limit.conf':
  ensure     => present,
  unit       => 'etc-passwd.path',
  path_entry => {
    'TriggerLimitBurst' => 100,
  },
}
```

https://www.freedesktop.org/software/systemd/man/systemd.path.html

Additional commits:
* Correct timer_entry error message on a non-timer
* Group spec expectations in a single example
