### PR TITLE
Increase inifile dependency upper version to < 7.0.0

### DIFF
--- a/metadata.json
+++ b/metadata.json
@@ -14,7 +14,7 @@
     },
     {
       "name": "puppetlabs/inifile",
-      "version_requirement": ">= 1.6.0 < 6.0.0"
+      "version_requirement": ">= 1.6.0 < 7.0.0"
     }
   ],
   "operatingsystem_support": [


### PR DESCRIPTION
#### Pull Request (PR) description

Puppetlabs-inifile v6.0.0 has been released yet this module locks to < 6.0.0. This can cause cascading issues installing the latest of other modules as a result.


#### This Pull Request (PR) fixes the following issues

Fixes https://github.com/voxpupuli/puppet-systemd/issues/336

