### PR TITLE
Allow LimitCORE in [Service] for manage_unit/dropin

### DIFF
--- a/REFERENCE.md
+++ b/REFERENCE.md
@@ -794,6 +794,18 @@ systemd::manage_dropin { 'triggerlimit.conf':
 }
 ```
 
+##### drop in file to override the LimitCORE for a service
+
+```puppet
+systemd::manage_dropin { 'corelimit.conf':
+  ensure     => present,
+  unit       => 'rsyslog.conf',
+  path_entry => {
+    'LimitCORE' => 'infinity',
+  },
+}
+```
+
 #### Parameters
 
 The following parameters are available in the `systemd::manage_dropin` defined type:
@@ -2259,6 +2271,7 @@ Struct[{
     Optional['KillSignal']                => Pattern[/^SIG[A-Z]+$/],
     Optional['KillMode']                  => Enum['control-group', 'mixed', 'process', 'none'],
     Optional['SyslogIdentifier']          => String,
+    Optional['LimitCORE']                 => Pattern['^(infinity|((\d+(K|M|G|T|P|E)?(:\d+(K|M|G|T|P|E)?)?)))$'],
     Optional['RestartSec']                => String,
     Optional['TimeoutStartSec']           => String,
     Optional['TimeoutStopSec']            => String,

--- a/manifests/manage_dropin.pp
+++ b/manifests/manage_dropin.pp
@@ -14,12 +14,21 @@
 #     },
 #   }
 #
-## @example drop in file to change a path unit and override TriggerLimitBurst
+# @example drop in file to change a path unit and override TriggerLimitBurst
 #   systemd::manage_dropin { 'triggerlimit.conf':
 #     ensure     => present,
 #     unit       => 'passwd.path',
 #     path_entry => {
 #       'TriggerLimitBurst' => 100,
+#     },
+#   }
+#
+# @example drop in file to override the LimitCORE for a service
+#   systemd::manage_dropin { 'corelimit.conf':
+#     ensure     => present,
+#     unit       => 'rsyslog.conf',
+#     path_entry => {
+#       'LimitCORE' => 'infinity',
 #     },
 #   }
 #

--- a/spec/defines/manage_dropin_spec.rb
+++ b/spec/defines/manage_dropin_spec.rb
@@ -24,13 +24,15 @@ describe 'systemd::manage_dropin' do
                   DefaultDependencies: true
                 },
                 service_entry: {
-                  SyslogIdentifier: 'simple'
+                  SyslogIdentifier: 'simple',
+                  LimitCORE: 'infinity',
                 }
               )
             end
 
             it {
               is_expected.to contain_systemd__dropin_file('foobar.conf').
+                with_content(%r{^LimitCORE=infinity$}).
                 with_content(%r{^DefaultDependencies=true$}).
                 with_content(%r{^SyslogIdentifier=simple$})
             }

--- a/spec/type_aliases/systemd_unit_service_spec.rb
+++ b/spec/type_aliases/systemd_unit_service_spec.rb
@@ -27,6 +27,9 @@ describe 'Systemd::Unit::Service' do
   it { is_expected.to allow_value({ 'KillSignal' => 'SIGTERM' }) }
   it { is_expected.not_to allow_value({ 'KillSignal' => 'SIGterm' }) }
   it { is_expected.not_to allow_value({ 'KillSignal' => 9 }) }
+  it { is_expected.to allow_value({ 'LimitCORE' => 'infinity' }) }
+  it { is_expected.to allow_value({ 'LimitCORE' => '100M' }) }
+  it { is_expected.not_to allow_value({ 'LimitCORE' => 'random string' }) }
 
   it { is_expected.to allow_value({ 'ExecStart' => 'notabsolute.sh' }) }
   it { is_expected.not_to allow_value({ 'ExecStart' => '*/wrongprefix.sh' }) }

--- a/types/unit/service.pp
+++ b/types/unit/service.pp
@@ -23,6 +23,7 @@ type Systemd::Unit::Service = Struct[
     Optional['KillSignal']                => Pattern[/^SIG[A-Z]+$/],
     Optional['KillMode']                  => Enum['control-group', 'mixed', 'process', 'none'],
     Optional['SyslogIdentifier']          => String,
+    Optional['LimitCORE']                 => Pattern['^(infinity|((\d+(K|M|G|T|P|E)?(:\d+(K|M|G|T|P|E)?)?)))$'],
     Optional['RestartSec']                => String,
     Optional['TimeoutStartSec']           => String,
     Optional['TimeoutStopSec']            => String,


### PR DESCRIPTION
#### Pull Request (PR) description

Addition of LimitCOR to `[service]` section of
`systemd::manage_unit` and `systemd::manage_dropin`

Added as penance for giving a wrong guess twice to someone how to do this. Always confuses me since while:

`systemctl show sshd.service -t LimitCORESoft` has a value it cannot be set as I understand it.

There is some duplication here with the existing `systemd::service_limits` but that is fine.

* https://www.freedesktop.org/software/systemd/man/systemd.exec.html#Process%20Properties
