### PR TITLE
No insistence on unit_entry ever or service_entry with absent manage_unit

### DIFF
--- a/REFERENCE.md
+++ b/REFERENCE.md
@@ -1037,6 +1037,13 @@ systemd::manage_unit{'arcd@.service':
     'ExecStart'     => /usr/sbin/arcd /usr/libexec/arcd/arcd.pl,
     'StandardInput' => 'socket',
   }
+```
+
+##### Remove a unit file
+
+```puppet
+systemd::manage_unit { 'my.service':
+  ensure     => 'absent',
 }
 ```
 
@@ -1168,9 +1175,11 @@ Default value: `true`
 
 ##### <a name="-systemd--manage_unit--unit_entry"></a>`unit_entry`
 
-Data type: `Systemd::Unit::Unit`
+Data type: `Optional[Systemd::Unit::Unit]`
 
 key value pairs for [Unit] section of the unit file.
+
+Default value: `undef`
 
 ##### <a name="-systemd--manage_unit--service_entry"></a>`service_entry`
 

--- a/manifests/manage_unit.pp
+++ b/manifests/manage_unit.pp
@@ -61,6 +61,10 @@
 #      'ExecStart'     => /usr/sbin/arcd /usr/libexec/arcd/arcd.pl,
 #      'StandardInput' => 'socket',
 #    }
+#
+# @example Remove a unit file
+#  systemd::manage_unit { 'my.service':
+#    ensure     => 'absent',
 #  }
 #
 # @param name [Pattern['^[^/]+\.(service|socket|device|mount|automount|swap|target|path|timer|slice|scope)$']]
@@ -103,7 +107,7 @@ define systemd::manage_unit (
   Hash[String[1], Any]                     $service_parameters      = {},
   Boolean                                  $daemon_reload           = true,
   Optional[Systemd::Unit::Install]         $install_entry           = undef,
-  Systemd::Unit::Unit                      $unit_entry,
+  Optional[Systemd::Unit::Unit]            $unit_entry              = undef,
   Optional[Systemd::Unit::Service]         $service_entry           = undef,
   Optional[Systemd::Unit::Timer]           $timer_entry             = undef,
   Optional[Systemd::Unit::Path]            $path_entry              = undef,
@@ -119,8 +123,8 @@ define systemd::manage_unit (
     fail("Systemd::Manage_unit[${name}]: path_entry is only valid for path units")
   }
 
-  if $name =~ Pattern['^[^/]+\.service'] and !$service_entry {
-    fail("Systemd::Manage_unit[${name}]: service_entry is only required for service units")
+  if $ensure != 'absent' and  $name =~ Pattern['^[^/]+\.service'] and !$service_entry {
+    fail("Systemd::Manage_unit[${name}]: service_entry is required for service units")
   }
 
   systemd::unit_file { $name:

--- a/spec/defines/manage_unit_spec.rb
+++ b/spec/defines/manage_unit_spec.rb
@@ -42,6 +42,24 @@ describe 'systemd::manage_unit' do
               with_content(%r{^Type=oneshot$})
           }
 
+          context 'with no service_entry' do
+            let(:params) do
+              {
+                ensure: 'present',
+              }
+            end
+
+            it { is_expected.to compile.and_raise_error(%r{service_entry is required for service units}) }
+
+            context 'with ensure absent' do
+              let(:params) do
+                super().merge(ensure: 'absent')
+              end
+
+              it { is_expected.to contain_systemd__unit_file('foobar.service').with_ensure('absent') }
+            end
+          end
+
           context 'with a timer entry' do
             let(:params) do
               super().merge(timer_entry: { 'OnCalendar' => 'something' })


### PR DESCRIPTION
#### Pull Request (PR) description

Removing a unit file with `systemd::manage_unit` with the following:

```
systemd::manage_unit {'foo.service':
  ensure     => 'absent',
}
```

This is not possible and a `service_entry` and `unit_entry` must be specified as the unit name
is in the service namespace.

Remove insistence for `unit_entry` and  `service_name` parameter for the absent case.

For the `ensure => 'present`` the `unit_entry` is no longer required since it is perfectly possible to create
units without any `[Unit]` section. 

Also improve failure message when `service_entry` is not specified for service unit.
