### PR TITLE
Relax stdlib dependency version requirements

### DIFF
--- a/metadata.json
+++ b/metadata.json
@@ -10,7 +10,7 @@
   "dependencies": [
     {
       "name": "puppetlabs/stdlib",
-      "version_requirement": ">= 4.13.1 < 9.0.0"
+      "version_requirement": ">= 4.13.1 < 10.0.0"
     },
     {
       "name": "puppetlabs/inifile",


### PR DESCRIPTION
* Allow puppetlabs-stdlib 9.x
