### PR TITLE
Allow WorkingDirectory to be specified in [Service]

### DIFF
--- a/REFERENCE.md
+++ b/REFERENCE.md
@@ -2316,6 +2316,7 @@ Struct[{
     Optional['AmbientCapabilities']       => Variant[Pattern[/^CAP_[A-Z_]+$/],Array[Pattern[/^CAP_[A-Z_]+$/],1]],
     Optional['User']                      => String[1],
     Optional['Group']                     => String[1],
+    Optional['WorkingDirectory']          => String[0],
     Optional['Type']                      => Enum['simple', 'exec', 'forking', 'oneshot', 'dbus', 'notify', 'idle'],
     Optional['ExitType']                  => Enum['main', 'cgroup'],
     Optional['RemainAfterExit']           => Boolean,

--- a/spec/type_aliases/systemd_unit_service_spec.rb
+++ b/spec/type_aliases/systemd_unit_service_spec.rb
@@ -44,4 +44,9 @@ describe 'Systemd::Unit::Service' do
   it { is_expected.to allow_value({ 'Group' => 'root' }) }
   it { is_expected.to allow_value({ 'StandardOutput' => 'null' }) }
   it { is_expected.to allow_value({ 'StandardError' => 'null' }) }
+
+  it { is_expected.to allow_value({ 'WorkingDirectory' => '/var/lib/here' }) }
+  it { is_expected.to allow_value({ 'WorkingDirectory' => '-/var/lib/here' }) }
+  it { is_expected.to allow_value({ 'WorkingDirectory' => '~' }) }
+  it { is_expected.to allow_value({ 'WorkingDirectory' => '' }) }
 end

--- a/types/unit/service.pp
+++ b/types/unit/service.pp
@@ -7,6 +7,7 @@ type Systemd::Unit::Service = Struct[
     Optional['AmbientCapabilities']       => Variant[Pattern[/^CAP_[A-Z_]+$/],Array[Pattern[/^CAP_[A-Z_]+$/],1]],
     Optional['User']                      => String[1],
     Optional['Group']                     => String[1],
+    Optional['WorkingDirectory']          => String[0],
     Optional['Type']                      => Enum['simple', 'exec', 'forking', 'oneshot', 'dbus', 'notify', 'idle'],
     Optional['ExitType']                  => Enum['main', 'cgroup'],
     Optional['RemainAfterExit']           => Boolean,


### PR DESCRIPTION
#### Pull Request (PR) description

Support use of `WorkingDirectory` directive in `[Service]` section of `systemd::manage_unit` and `systemd::manage_dropin`

https://www.freedesktop.org/software/systemd/man/systemd.exec.html#WorkingDirectory=

#### This Pull Request (PR) fixes the following issues

Fixes: #299
