### PR TITLE
Support StandardOutput, StandardError and RequiresMountsFor.

### DIFF
--- a/REFERENCE.md
+++ b/REFERENCE.md
@@ -2358,6 +2358,8 @@ Struct[{
       Stdlib::Unixpath,Pattern[/-\/.+/],
       Array[Variant[Stdlib::Unixpath,Pattern[/-\/.+/]],1],
     ],
+    Optional['StandardOutput']            => Variant[Enum['inherit','null','tty','journal','kmsg','journal+console','kmsg+console','socket'],Pattern[/\A(file:|append:|truncate:).+$\z/]],
+    Optional['StandardError']             => Variant[Enum['inherit','null','tty','journal','kmsg','journal+console','kmsg+console','socket'],Pattern[/\A(file:|append:|truncate:).+$\z/]],
   }]
 ```
 
@@ -2496,6 +2498,7 @@ Struct[{
     Optional['After']                    => Variant[Enum[''],Systemd::Unit,Array[Variant[Enum[''],Systemd::Unit],1]],
     Optional['OnFailure']                => Variant[Enum[''],Systemd::Unit,Array[Variant[Enum[''],Systemd::Unit],1]],
     Optional['OnSuccess']                => Variant[Enum[''],Systemd::Unit,Array[Variant[Enum[''],Systemd::Unit],1]],
+    Optional['RequiresMountsFor']        => Variant[Enum[''],Stdlib::Unixpath,Array[Variant[Enum[''],Stdlib::Unixpath],1]],
     # Conditions and Asserts
     Optional['ConditionPathExists']      => Variant[Enum[''],Stdlib::Unixpath,Pattern[/^!.*$/],Array[Variant[Enum[''],Stdlib::Unixpath,Pattern[/^!.*$/]],1]],
     Optional['ConditionPathIsDirectory'] => Variant[Enum[''],Stdlib::Unixpath,Pattern[/^!.*$/],Array[Variant[Enum[''],Stdlib::Unixpath,Pattern[/^!.*$/]],1]],

--- a/spec/type_aliases/systemd_unit_service_spec.rb
+++ b/spec/type_aliases/systemd_unit_service_spec.rb
@@ -39,4 +39,9 @@ describe 'Systemd::Unit::Service' do
   it { is_expected.to allow_value({ 'EnvironmentFile' => ['/etc/sysconfig/foo', '-/etc/sysconfig/foo-bar'] }) }
   it { is_expected.not_to allow_value({ 'EnvironmentFile' => '-/' }) }
   it { is_expected.not_to allow_value({ 'EnvironmentFile' => 'relative-path.sh' }) }
+
+  it { is_expected.to allow_value({ 'User' => 'root' }) }
+  it { is_expected.to allow_value({ 'Group' => 'root' }) }
+  it { is_expected.to allow_value({ 'StandardOutput' => 'null' }) }
+  it { is_expected.to allow_value({ 'StandardError' => 'null' }) }
 end

--- a/spec/type_aliases/systemd_unit_unit_spec.rb
+++ b/spec/type_aliases/systemd_unit_unit_spec.rb
@@ -52,4 +52,11 @@ describe 'Systemd::Unit::Unit' do
   it { is_expected.not_to allow_value({ 'Wants' => ['noextension'] }) }
   it { is_expected.not_to allow_value({ 'ConditionPathExists' => 'not/an/absolute/path' }) }
   it { is_expected.not_to allow_value({ 'ConditionPathExists' => ['not/an/absolute/path'] }) }
+
+  it { is_expected.to allow_value({ 'RequiresMountsFor' => '/an/absolute/path' }) }
+  it { is_expected.to allow_value({ 'RequiresMountsFor' => '' }) }
+  it { is_expected.to allow_value({ 'RequiresMountsFor' => ['', '/an/absolute/path'] }) }
+  it { is_expected.not_to allow_value({ 'RequiresMountsFor' => 'not/an/absolute/path' }) }
+  it { is_expected.not_to allow_value({ 'RequiresMountsFor' => ['not/a/path'] }) }
+  it { is_expected.not_to allow_value({ 'RequiresMountsFor' => [] }) }
 end

--- a/types/unit/service.pp
+++ b/types/unit/service.pp
@@ -49,5 +49,7 @@ type Systemd::Unit::Service = Struct[
       Stdlib::Unixpath,Pattern[/-\/.+/],
       Array[Variant[Stdlib::Unixpath,Pattern[/-\/.+/]],1],
     ],
+    Optional['StandardOutput']            => Variant[Enum['inherit','null','tty','journal','kmsg','journal+console','kmsg+console','socket'],Pattern[/\A(file:|append:|truncate:).+$\z/]],
+    Optional['StandardError']             => Variant[Enum['inherit','null','tty','journal','kmsg','journal+console','kmsg+console','socket'],Pattern[/\A(file:|append:|truncate:).+$\z/]],
   }
 ]

--- a/types/unit/unit.pp
+++ b/types/unit/unit.pp
@@ -16,6 +16,7 @@ type Systemd::Unit::Unit = Struct[
     Optional['After']                    => Variant[Enum[''],Systemd::Unit,Array[Variant[Enum[''],Systemd::Unit],1]],
     Optional['OnFailure']                => Variant[Enum[''],Systemd::Unit,Array[Variant[Enum[''],Systemd::Unit],1]],
     Optional['OnSuccess']                => Variant[Enum[''],Systemd::Unit,Array[Variant[Enum[''],Systemd::Unit],1]],
+    Optional['RequiresMountsFor']        => Variant[Enum[''],Stdlib::Unixpath,Array[Variant[Enum[''],Stdlib::Unixpath],1]],
     # Conditions and Asserts
     Optional['ConditionPathExists']      => Variant[Enum[''],Stdlib::Unixpath,Pattern[/^!.*$/],Array[Variant[Enum[''],Stdlib::Unixpath,Pattern[/^!.*$/]],1]],
     Optional['ConditionPathIsDirectory'] => Variant[Enum[''],Stdlib::Unixpath,Pattern[/^!.*$/],Array[Variant[Enum[''],Stdlib::Unixpath,Pattern[/^!.*$/]],1]],


### PR DESCRIPTION
#### Pull Request (PR) description

* Allow  `StandardOutput` and `StandardError` in `[Service]` section.
* Allow  `RequireMountsFor` in `[Unit]` section.

* https://www.freedesktop.org/software/systemd/man/systemd.exec.html#StandardOutput=
* https://www.freedesktop.org/software/systemd/man/systemd.exec.html#StandardError=
* https://www.freedesktop.org/software/systemd/man/systemd.unit.html#RequiresMountsFor=

Note documentation for RequiresMountsFor is actually incomplete [1]

* [1] https://serverfault.com/questions/1085820/systemd-requiresmountsfor-multiline-syntax

#### This Pull Request (PR) fixes the following issues
Fixes: #321

