### PR TITLE
Correct syntax in manage_unit socket example

### DIFF
--- a/REFERENCE.md
+++ b/REFERENCE.md
@@ -1019,6 +1019,7 @@ systemd::manage_unit {'arcd.socket':
     'ListenStream' => 4241,
     'Accept'       => true,
     'BindIPv6Only' => 'both',
+  },
   install_entry => {
     'WantedBy' => 'sockets.target',
   }

--- a/manifests/manage_unit.pp
+++ b/manifests/manage_unit.pp
@@ -43,6 +43,7 @@
 #      'ListenStream' => 4241,
 #      'Accept'       => true,
 #      'BindIPv6Only' => 'both',
+#    },
 #    install_entry => {
 #      'WantedBy' => 'sockets.target',
 #    }


### PR DESCRIPTION
Fixes: 5371ac0db747 ("Socket support for manage unit and dropin")