### PR TITLE
Allow LogLevelMax to be set in [Service]

### DIFF
--- a/REFERENCE.md
+++ b/REFERENCE.md
@@ -807,6 +807,18 @@ systemd::manage_dropin { 'corelimit.conf':
 }
 ```
 
+##### make a noisy unit less noisy
+
+```puppet
+systemd::manage_dropin { 'maxloglevel.conf':
+  ensure        => present,
+  unit          => 'chatty.service',
+  service_entry => {
+    'LogLevelMax' => 'warning',
+  }
+}
+```
+
 #### Parameters
 
 The following parameters are available in the `systemd::manage_dropin` defined type:
@@ -2334,6 +2346,7 @@ Struct[{
     Optional['KillSignal']                => Pattern[/^SIG[A-Z]+$/],
     Optional['KillMode']                  => Enum['control-group', 'mixed', 'process', 'none'],
     Optional['SyslogIdentifier']          => String,
+    Optional['LogLevelMax']               => Enum['emerg','alert','crit','err','warning','notice','info','debug'],
     Optional['LimitCORE']                 => Pattern['^(infinity|((\d+(K|M|G|T|P|E)?(:\d+(K|M|G|T|P|E)?)?)))$'],
     Optional['RestartSec']                => String,
     Optional['TimeoutStartSec']           => String,

--- a/manifests/manage_dropin.pp
+++ b/manifests/manage_dropin.pp
@@ -32,6 +32,15 @@
 #     },
 #   }
 #
+# @example make a noisy unit less noisy
+#   systemd::manage_dropin { 'maxloglevel.conf':
+#     ensure        => present,
+#     unit          => 'chatty.service',
+#     service_entry => {
+#       'LogLevelMax' => 'warning',
+#     }
+#   }
+#
 # @param unit The unit to create a dropfile for
 # @param filename The target unit file to create. The filename of the drop in. The full path is determined using the path, unit and this filename.
 # @param ensure The state of this dropin file

--- a/spec/type_aliases/systemd_unit_service_spec.rb
+++ b/spec/type_aliases/systemd_unit_service_spec.rb
@@ -49,4 +49,7 @@ describe 'Systemd::Unit::Service' do
   it { is_expected.to allow_value({ 'WorkingDirectory' => '-/var/lib/here' }) }
   it { is_expected.to allow_value({ 'WorkingDirectory' => '~' }) }
   it { is_expected.to allow_value({ 'WorkingDirectory' => '' }) }
+
+  it { is_expected.to allow_value({ 'LogLevelMax' => 'alert' }) }
+  it { is_expected.not_to allow_value({ 'LogLevelMax' => 'top' }) }
 end

--- a/types/unit/service.pp
+++ b/types/unit/service.pp
@@ -24,6 +24,7 @@ type Systemd::Unit::Service = Struct[
     Optional['KillSignal']                => Pattern[/^SIG[A-Z]+$/],
     Optional['KillMode']                  => Enum['control-group', 'mixed', 'process', 'none'],
     Optional['SyslogIdentifier']          => String,
+    Optional['LogLevelMax']               => Enum['emerg','alert','crit','err','warning','notice','info','debug'],
     Optional['LimitCORE']                 => Pattern['^(infinity|((\d+(K|M|G|T|P|E)?(:\d+(K|M|G|T|P|E)?)?)))$'],
     Optional['RestartSec']                => String,
     Optional['TimeoutStartSec']           => String,


### PR DESCRIPTION
#### Pull Request (PR) description

```puppet
systemd::manage_dropin { 'maxloglevel.conf':
  ensure        => present,
  unit          => 'chatty.service',
  service_entry => {
    'LogLevelMax' => 'warning',
  }
}
```

https://www.freedesktop.org/software/systemd/man/systemd.exec.html#LogLevelMax=
