### PR TITLE
Support Debian 12

### DIFF
--- a/README.md
+++ b/README.md
@@ -351,7 +351,7 @@ class { 'systemd':
 }
 ```
 
-when `manage_systemd` is true any required sub package, e.g. `systemd-resolved` on CentOS 9, will be installed. However configuration of
+when `manage_systemd` is true any required sub package, e.g. `systemd-resolved` on CentOS 9 or Debian 12, will be installed. However configuration of
 systemd-resolved will only occur on second puppet run after that installation.
 
 This requires [puppetlabs-inifile](https://forge.puppet.com/puppetlabs/inifile), which is only a soft dependency in this module (you need to explicitly install it). Both parameters accept a string or an array.

--- a/spec/acceptance/resolved_spec.rb
+++ b/spec/acceptance/resolved_spec.rb
@@ -3,6 +3,8 @@
 require 'spec_helper_acceptance'
 
 describe 'systemd with manage_resolved true' do
+  has_package = (fact('os.family') == 'RedHat' && fact('os.release.major') != '8') || (fact('os.name') == 'Debian' && fact('os.release.major').to_i >= 12)
+
   context 'configure systemd resolved' do
     it 'works idempotently with no errors' do
       pp = <<-PUPPET
@@ -13,10 +15,7 @@ describe 'systemd with manage_resolved true' do
       PUPPET
       apply_manifest(pp, catch_failures: true)
       # RedHat 7, 9, Debian 12 and newer installs package first run before fact $facts['internal_services'] is set
-      if (fact('os.release.major') != '8' && (fact('os.family') == 'RedHat')) ||
-         ((fact('os.name') == 'Debian' && fact('os.release.major').to_i >= 12))
-        apply_manifest(pp, catch_failures: true)
-      end
+      apply_manifest(pp, catch_failures: true) if has_package
       apply_manifest(pp, catch_changes: true)
     end
 
@@ -24,6 +23,8 @@ describe 'systemd with manage_resolved true' do
       it { is_expected.to be_running }
       it { is_expected.to be_enabled }
     end
+
+    it { expect(package('systemd-resolved')).to be_installed } if has_package
   end
 
   context 'configure systemd stopped' do

--- a/spec/acceptance/resolved_spec.rb
+++ b/spec/acceptance/resolved_spec.rb
@@ -12,8 +12,11 @@ describe 'systemd with manage_resolved true' do
       }
       PUPPET
       apply_manifest(pp, catch_failures: true)
-      # RedHat 7, 9 and newer installs package first run before fact $facts['internal_services'] is set
-      apply_manifest(pp, catch_failures: true) if fact('os.release.major') != '8' && (fact('os.family') == 'RedHat')
+      # RedHat 7, 9, Debian 12 and newer installs package first run before fact $facts['internal_services'] is set
+      if (fact('os.release.major') != '8' && (fact('os.family') == 'RedHat')) ||
+         ((fact('os.name') == 'Debian' && fact('os.release.major').to_i >= 12))
+        apply_manifest(pp, catch_failures: true)
+      end
       apply_manifest(pp, catch_changes: true)
     end
 

--- a/spec/classes/init_spec.rb
+++ b/spec/classes/init_spec.rb
@@ -47,7 +47,7 @@ describe 'systemd' do
           end
 
           case [facts[:os]['family'], facts[:os]['release']['major']]
-          when %w[RedHat 7], %w[RedHat 9]
+          when %w[RedHat 7], %w[RedHat 9], %w[Debian 12]
             it { is_expected.to contain_package('systemd-resolved') }
           else
             it { is_expected.not_to contain_package('systemd-resolved') }


### PR DESCRIPTION
#### Pull Request (PR) description

In particular with Debian 11->12 systemd-resolved is now a sub package
that must be installed.

Clearly there are no tests running for Debian 12 yet.
