### PR TITLE
allow to set StandardInput on service unit

### DIFF
--- a/REFERENCE.md
+++ b/REFERENCE.md
@@ -2377,6 +2377,7 @@ Struct[{
     ],
     Optional['StandardOutput']            => Variant[Enum['inherit','null','tty','journal','kmsg','journal+console','kmsg+console','socket'],Pattern[/\A(file:|append:|truncate:).+$\z/]],
     Optional['StandardError']             => Variant[Enum['inherit','null','tty','journal','kmsg','journal+console','kmsg+console','socket'],Pattern[/\A(file:|append:|truncate:).+$\z/]],
+    Optional['StandardInput']             => Variant[Enum['null','tty','tty-force','tty-fail','data','socket'], Pattern[/\A(file:|fd:).+$\z/]],
   }]
 ```
 

--- a/spec/type_aliases/systemd_unit_service_spec.rb
+++ b/spec/type_aliases/systemd_unit_service_spec.rb
@@ -49,7 +49,6 @@ describe 'Systemd::Unit::Service' do
   it { is_expected.to allow_value({ 'StandardInput' => 'file:/tmp/inputfile' }) }
   it { is_expected.not_to allow_value({ 'StandardInput' => '/tmp/inputfile' }) }
 
-
   it { is_expected.to allow_value({ 'DynamicUser' => false }) }
   it { is_expected.to allow_value({ 'DynamicUser' => true }) }
   it { is_expected.not_to allow_value({ 'DynamicUser' => 'maybe' }) }

--- a/spec/type_aliases/systemd_unit_service_spec.rb
+++ b/spec/type_aliases/systemd_unit_service_spec.rb
@@ -45,6 +45,11 @@ describe 'Systemd::Unit::Service' do
   it { is_expected.to allow_value({ 'StandardOutput' => 'null' }) }
   it { is_expected.to allow_value({ 'StandardError' => 'null' }) }
 
+  it { is_expected.to allow_value({ 'StandardInput' => 'socket' }) }
+  it { is_expected.to allow_value({ 'StandardInput' => 'file:/tmp/inputfile' }) }
+  it { is_expected.not_to allow_value({ 'StandardInput' => '/tmp/inputfile' }) }
+
+
   it { is_expected.to allow_value({ 'DynamicUser' => false }) }
   it { is_expected.to allow_value({ 'DynamicUser' => true }) }
   it { is_expected.not_to allow_value({ 'DynamicUser' => 'maybe' }) }

--- a/types/unit/service.pp
+++ b/types/unit/service.pp
@@ -55,5 +55,6 @@ type Systemd::Unit::Service = Struct[
     ],
     Optional['StandardOutput']            => Variant[Enum['inherit','null','tty','journal','kmsg','journal+console','kmsg+console','socket'],Pattern[/\A(file:|append:|truncate:).+$\z/]],
     Optional['StandardError']             => Variant[Enum['inherit','null','tty','journal','kmsg','journal+console','kmsg+console','socket'],Pattern[/\A(file:|append:|truncate:).+$\z/]],
+    Optional['StandardInput']             => Variant[Enum['null','tty','tty-force','tty-fail','data','socket'], Pattern[/\A(file:|fd:).+$\z/]],
   }
 ]


### PR DESCRIPTION
#### Pull Request (PR) description
allow to set StandardInput like it is in the example for xinetd style systemd socket: https://github.com/voxpupuli/puppet-systemd/blob/master/manifests/manage_unit.pp#L63

* https://www.freedesktop.org/software/systemd/man/systemd.exec.html#StandardInput=
  