### PR TITLE
Drop Ubuntu 18.04 which went out of standard support in May 2023

### DIFF
--- a/data/Ubuntu-18.04.yaml
+++ b/data/Ubuntu-18.04.yaml
@@ -1,8 +1,0 @@
----
-systemd::accounting:
-  DefaultCPUAccounting: 'yes'
-  DefaultIOAccounting: 'yes'
-  DefaultIPAccounting: 'yes'
-  DefaultBlockIOAccounting: 'yes'
-  DefaultMemoryAccounting: 'yes'
-  DefaultTasksAccounting: 'yes'

--- a/metadata.json
+++ b/metadata.json
@@ -28,7 +28,6 @@
     {
       "operatingsystem": "Ubuntu",
       "operatingsystemrelease": [
-        "18.04",
         "20.04",
         "22.04"
       ]


### PR DESCRIPTION
https://ubuntu.com/blog/18-04-end-of-standard-support