### PR TITLE
Drop OracleLinux 7 from metadata.json

### DIFF
--- a/metadata.json
+++ b/metadata.json
@@ -78,7 +78,6 @@
     {
       "operatingsystem": "OracleLinux",
       "operatingsystemrelease": [
-        "7",
         "8"
       ]
     },


### PR DESCRIPTION
This module doesn't have OracleLinux 7 specific code. We enabled acceptance tests after OracleLinux 7 was added to metadata.json. We learned that the OracleLinux 7 repos are broken and we cannot test it. We are purging it from all modules. Because of that we don't label it as backwards-incompatible.