### PR TITLE
Correct coredump parameter from MaxFree to KeepFree

### DIFF
--- a/README.md
+++ b/README.md
@@ -452,7 +452,7 @@ class{'systemd':
     'ExternalSizeMax' => '10G',
     'JournalSizeMax'  => '20T',
     'MaxUse'          => '1E',
-    "MaxFree'         => '1P',
+    "KeepFree'        => '1P',
   }
 }
 ```

--- a/README.md
+++ b/README.md
@@ -452,7 +452,7 @@ class{'systemd':
     'ExternalSizeMax' => '10G',
     'JournalSizeMax'  => '20T',
     'MaxUse'          => '1E',
-    "KeepFree'        => '1P',
+    'KeepFree'        => '1P',
   }
 }
 ```

--- a/REFERENCE.md
+++ b/REFERENCE.md
@@ -2095,7 +2095,7 @@ Struct[{
     Optional['ExternalSizeMax'] => Pattern[/^[0-9]+(K|M|G|T|P|E)?$/],
     Optional['JournalSizeMax']  => Pattern[/^[0-9]+(K|M|G|T|P|E)?$/],
     Optional['MaxUse']          => Pattern[/^[0-9]+(K|M|G|T|P|E)?$/],
-    Optional['MaxFree']         => Pattern[/^[0-9]+(K|M|G|T|P|E)?$/],
+    Optional['KeepFree']        => Pattern[/^[0-9]+(K|M|G|T|P|E)?$/],
   }]
 ```
 

--- a/spec/type_aliases/systemd_coredumpsettings_spec.rb
+++ b/spec/type_aliases/systemd_coredumpsettings_spec.rb
@@ -14,7 +14,7 @@ describe 'Systemd::CoredumpSettings' do
         'ExternalSizeMax' => '456G',
         'JournalSizeMax' => '45T',
         'MaxUse' => '1P',
-        'MaxFree' => '1E',
+        'KeepFree' => '1E',
       }
     )
   }
@@ -28,7 +28,7 @@ describe 'Systemd::CoredumpSettings' do
         'ExternalSizeMax' => '456',
         'JournalSizeMax' => '45',
         'MaxUse' => '1',
-        'MaxFree' => '5',
+        'KeepFree' => '5',
       }
     )
   }
@@ -37,6 +37,7 @@ describe 'Systemd::CoredumpSettings' do
   it { is_expected.not_to allow_value({ 'Compress' => 'maybe' }) }
   it { is_expected.not_to allow_value({ 'MaxUse' => '-10' }) }
   it { is_expected.not_to allow_value({ 'MaxFee' => '10Gig' }) }
+  it { is_expected.not_to allow_value({ 'MaxFree' => '10' }) }
   it { is_expected.not_to allow_value({ 'ProcessSizeMax' => '20g' }) }
   it { is_expected.not_to allow_value({ 'JournalSizeMax' => '20Z' }) }
 end

--- a/types/coredumpsettings.pp
+++ b/types/coredumpsettings.pp
@@ -9,6 +9,6 @@ type Systemd::CoredumpSettings = Struct[
     Optional['ExternalSizeMax'] => Pattern[/^[0-9]+(K|M|G|T|P|E)?$/],
     Optional['JournalSizeMax']  => Pattern[/^[0-9]+(K|M|G|T|P|E)?$/],
     Optional['MaxUse']          => Pattern[/^[0-9]+(K|M|G|T|P|E)?$/],
-    Optional['MaxFree']         => Pattern[/^[0-9]+(K|M|G|T|P|E)?$/],
+    Optional['KeepFree']        => Pattern[/^[0-9]+(K|M|G|T|P|E)?$/],
   }
 ]


### PR DESCRIPTION
#### Pull Request (PR) description

Incorrect coredump paramters were added.

It should be `KeepFree` and `MaxFree` was never valid.

https://www.freedesktop.org/software/systemd/man/latest/coredump.conf.html#MaxUse=

#### This Pull Request (PR) fixes the following issues

* Fixes #398
