### PR TITLE
Allow percent (%) character in unit names.

### DIFF
--- a/REFERENCE.md
+++ b/REFERENCE.md
@@ -837,6 +837,18 @@ systemd::manage_dropin { 'maxloglevel.conf':
 }
 ```
 
+##### have a unit instance auto run before user-<uid>.service
+
+```puppet
+systemd::manage_dropin { 'user-aklog.conf':
+  unit => 'user@.service',
+  unit_entry => {
+    'After'    => 'user-aklog@%i.service',
+    'Requires' => 'user-aklog@%i.service'
+  }
+}
+```
+
 #### Parameters
 
 The following parameters are available in the `systemd::manage_dropin` defined type:
@@ -2289,7 +2301,7 @@ custom datatype that validates different filenames for systemd units and unit te
 * **See also**
   * https://www.freedesktop.org/software/systemd/man/systemd.unit.html
 
-Alias of `Pattern[/^[a-zA-Z0-9:\-_.\\@]+\.(service|socket|device|mount|automount|swap|target|path|timer|slice|scope)$/]`
+Alias of `Pattern[/^[a-zA-Z0-9:\-_.\\@%]+\.(service|socket|device|mount|automount|swap|target|path|timer|slice|scope)$/]`
 
 ### <a name="Systemd--Unit--Install"></a>`Systemd::Unit::Install`
 

--- a/manifests/manage_dropin.pp
+++ b/manifests/manage_dropin.pp
@@ -41,6 +41,15 @@
 #     }
 #   }
 #
+# @example have a unit instance auto run before user-<uid>.service
+#  systemd::manage_dropin { 'user-aklog.conf':
+#    unit => 'user@.service',
+#    unit_entry => {
+#      'After'    => 'user-aklog@%i.service',
+#      'Requires' => 'user-aklog@%i.service'
+#    }
+#  }
+#
 # @param unit The unit to create a dropfile for
 # @param filename The target unit file to create. The filename of the drop in. The full path is determined using the path, unit and this filename.
 # @param ensure The state of this dropin file

--- a/spec/defines/manage_dropin_spec.rb
+++ b/spec/defines/manage_dropin_spec.rb
@@ -64,6 +64,23 @@ describe 'systemd::manage_dropin' do
             }
           end
 
+          context 'with an instance to instance relation' do
+            let(:params) do
+              super().merge(
+                unit_entry: {
+                  'After'    => ['user-runtime-dir@%i.service'],
+                  'Requires' => ['user-runtime-dir@%i.service'],
+                }
+              )
+            end
+
+            it {
+              is_expected.to contain_systemd__dropin_file('foobar.conf').
+                with_content(%r{^After=user-runtime-dir@%i.service$}).
+                with_content(%r{^Requires=user-runtime-dir@%i.service$})
+            }
+          end
+
           context 'with a timer entry' do
             let(:params) do
               super().merge(

--- a/spec/type_aliases/unit_spec.rb
+++ b/spec/type_aliases/unit_spec.rb
@@ -13,6 +13,7 @@ describe 'Systemd::Unit' do
       'extra.dot.scope',
       'a:colon.path',
       'an_underscore.device',
+      'a_referenced_template_instance@%i.service',
       'a-dash.slice',
     ].each do |unit|
       it { is_expected.to allow_value(unit.to_s) }

--- a/types/unit.pp
+++ b/types/unit.pp
@@ -1,3 +1,3 @@
 # @summary custom datatype that validates different filenames for systemd units and unit templates
 # @see https://www.freedesktop.org/software/systemd/man/systemd.unit.html
-type Systemd::Unit = Pattern[/^[a-zA-Z0-9:\-_.\\@]+\.(service|socket|device|mount|automount|swap|target|path|timer|slice|scope)$/]
+type Systemd::Unit = Pattern[/^[a-zA-Z0-9:\-_.\\@%]+\.(service|socket|device|mount|automount|swap|target|path|timer|slice|scope)$/]


### PR DESCRIPTION
#### Pull Request (PR) description

This allows relations to be set up between similar instances of two templated units.

For example:

```puppet
systemd::manage_dropin{'user-aklog.conf':
  ensure     => present,
  unit       => 'user@.service',
  unit_entry => {
    'Documentation' => 'Run an aklog before we start systemd --user',
    'After'         => ['user-aklog@%i.service'],
    'Requires'      => ['user-aklog@%i.service'],
  },
}
```

Previously the `%` character was considered illegal in a unit name.