### PR TITLE
systemd::cache = false result was vague.

### DIFF
--- a/REFERENCE.md
+++ b/REFERENCE.md
@@ -275,11 +275,11 @@ Default value: `false`
 
 ##### <a name="-systemd--cache"></a>`cache`
 
-Data type: `Variant[Boolean,Enum['no-negative']]`
+Data type: `Optional[Variant[Boolean,Enum['no-negative']]]`
 
-Takes a boolean argument or "no-negative".
+Takes a boolean argument or "no-negative". If left `undef` the cache setting will not be modified.
 
-Default value: `false`
+Default value: `undef`
 
 ##### <a name="-systemd--dns_stub_listener"></a>`dns_stub_listener`
 

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -61,7 +61,7 @@
 #   "opportunistic" and "false" (default) to "no".
 #
 # @param cache
-#   Takes a boolean argument or "no-negative".
+#   Takes a boolean argument or "no-negative". If left `undef` the cache setting will not be modified.
 #
 # @param dns_stub_listener
 #   Takes a boolean argument or one of "udp" and "tcp".
@@ -201,7 +201,7 @@ class systemd (
   Optional[Variant[Boolean,Enum['resolve']]]          $multicast_dns = undef,
   Optional[Variant[Boolean,Enum['allow-downgrade']]]  $dnssec = undef,
   Variant[Boolean,Enum['yes', 'opportunistic', 'no']] $dnsovertls = false,
-  Variant[Boolean,Enum['no-negative']]                $cache = false,
+  Optional[Variant[Boolean,Enum['no-negative']]]      $cache = undef,
   Optional[Variant[Boolean,Enum['udp','tcp']]]        $dns_stub_listener = undef,
   Optional[Array[String[1]]] $dns_stub_listener_extra = undef,
   Boolean                                             $manage_resolv_conf = true,

--- a/manifests/resolved.pp
+++ b/manifests/resolved.pp
@@ -222,7 +222,7 @@ class systemd::resolved (
     default => $cache,
   }
 
-  if $cache {
+  if $_cache {
     ini_setting { 'cache':
       ensure  => 'present',
       value   => $_cache,

--- a/spec/classes/init_spec.rb
+++ b/spec/classes/init_spec.rb
@@ -194,6 +194,25 @@ describe 'systemd' do
           }
         end
 
+        context 'when enabling resolved with false cache variant' do
+          let(:params) do
+            {
+              manage_resolved: true,
+              cache: false,
+            }
+          end
+
+          it { is_expected.to create_service('systemd-resolved').with_ensure('running') }
+          it { is_expected.to create_service('systemd-resolved').with_enable(true) }
+
+          it {
+            expect(subject).to contain_ini_setting('cache').with(
+              path: '/etc/systemd/resolved.conf',
+              value: 'no'
+            )
+          }
+        end
+
         context 'with alternate target' do
           let(:params) do
             {


### PR DESCRIPTION
#### Pull Request (PR) description

Starting with

```puppet
class{ 'systemd':
  manage_reolved => true,
  cache          => false,
}
```

note that the cache parameter is currently `false` by default and an explicit `Cache=no` would not be set. Instead nothing would be done.

This patch maintains backwards compatibility in that the default still results in no modification to `/etc/systemd/resolved.conf`.

However an explicit setting of `cache => false` with this patch will now add `Cache=no` to `resolved.conf`.
