### PR TITLE
`systemd::unit_file`: Ensure link gets removed on `ensure => absent`

### DIFF
--- a/manifests/unit_file.pp
+++ b/manifests/unit_file.pp
@@ -93,7 +93,10 @@ define systemd::unit_file (
   }
 
   if $_target {
-    $_ensure = 'link'
+    $_ensure = $ensure ? {
+      'absent' => 'absent',
+      default  => 'link',
+    }
   } else {
     $_ensure = $ensure ? {
       'present' => 'file',

--- a/manifests/unit_file.pp
+++ b/manifests/unit_file.pp
@@ -93,15 +93,9 @@ define systemd::unit_file (
   }
 
   if $_target {
-    $_ensure = $ensure ? {
-      'absent' => 'absent',
-      default  => 'link',
-    }
+    $_ensure = stdlib::ensure($ensure, 'link')
   } else {
-    $_ensure = $ensure ? {
-      'present' => 'file',
-      default   => $ensure,
-    }
+    $_ensure = stdlib::ensure($ensure, 'file')
   }
 
   file { "${path}/${name}":

--- a/metadata.json
+++ b/metadata.json
@@ -10,7 +10,7 @@
   "dependencies": [
     {
       "name": "puppetlabs/stdlib",
-      "version_requirement": ">= 4.13.1 < 10.0.0"
+      "version_requirement": ">= 6.6.0 < 10.0.0"
     },
     {
       "name": "puppetlabs/inifile",

--- a/spec/defines/unit_file_spec.rb
+++ b/spec/defines/unit_file_spec.rb
@@ -184,6 +184,20 @@ describe 'systemd::unit_file' do
             expect(subject).not_to create_systemd__daemon_reload(title)
           }
         end
+
+        context 'with target => "/tmp/service-target" and ensure => absent' do
+          let(:params) do
+            { ensure: 'absent', target: '/tmp/service-target' }
+          end
+
+          it { is_expected.to compile.with_all_deps }
+
+          it do
+            expect(subject).to create_file("/etc/systemd/system/#{title}").
+              with_ensure('absent').
+              with_target('/tmp/service-target')
+          end
+        end
       end
     end
   end


### PR DESCRIPTION
<!--
Thank you for contributing to this project!

- This project has a Contributor Code of Conduct: https://voxpupuli.org/coc/
- Please check that here is no existing issue or PR that addresses your problem.
- Our vulnerabilities reporting process is at https://voxpupuli.org/security/

-->
#### Pull Request (PR) description
Currently the `systemd::unit_file` type ignores the `ensure` parameter if `target` is defined. This allows the `ensure` parameter to be absent and thus removing the unit file if `target` is set.

#### This Pull Request (PR) fixes the following issues
<!--
Replace this comment with the list of issues or n/a.
Use format:
Fixes #123
Fixes #124
-->
