### PR TITLE
Support multiple Environment Settings

### DIFF
--- a/REFERENCE.md
+++ b/REFERENCE.md
@@ -2444,7 +2444,7 @@ Struct[{
     Optional['NotifyAccess']              => Enum['none', 'default', 'main', 'exec',  'all'],
     Optional['OOMPolicy']                 => Enum['continue', 'stop','kill'],
     Optional['OOMScoreAdjust']            => Integer[-1000,1000],
-    Optional['Environment']               => String,
+    Optional['Environment']               => Variant[String[0],Array[String[1],1]],
     Optional['EnvironmentFile']           => Variant[
       Stdlib::Unixpath,Pattern[/-\/.+/],
       Array[Variant[Stdlib::Unixpath,Pattern[/-\/.+/]],1],

--- a/spec/defines/manage_unit_spec.rb
+++ b/spec/defines/manage_unit_spec.rb
@@ -21,6 +21,7 @@ describe 'systemd::manage_unit' do
                 Type: 'oneshot',
                 ExecStart: '/usr/bin/doit.sh',
                 SyslogIdentifier: 'doit-backwards.sh',
+                Environment: ['bla=foo', 'foo=bla']
               },
               install_entry: {
                 WantedBy: 'multi-user.target',
@@ -36,6 +37,8 @@ describe 'systemd::manage_unit' do
               with_content(%r{^DefaultDependencies=true$}).
               with_content(%r{^\[Service\]$}).
               with_content(%r{^SyslogIdentifier=doit-backwards\.sh$}).
+              with_content(%r{^Environment=bla=foo$}).
+              with_content(%r{^Environment=foo=bla$}).
               with_content(%r{^\[Install\]$}).
               with_content(%r{^Description=My great service$}).
               with_content(%r{^Description=has two lines of description$}).

--- a/spec/type_aliases/systemd_unit_service_spec.rb
+++ b/spec/type_aliases/systemd_unit_service_spec.rb
@@ -34,6 +34,9 @@ describe 'Systemd::Unit::Service' do
   it { is_expected.to allow_value({ 'ExecStart' => 'notabsolute.sh' }) }
   it { is_expected.not_to allow_value({ 'ExecStart' => '*/wrongprefix.sh' }) }
 
+  it { is_expected.to allow_value({ 'Environment' => '' }) }
+  it { is_expected.to allow_value({ 'Environment' => 'FOO=BAR' }) }
+  it { is_expected.to allow_value({ 'Environment' => ['FOO=BAR', 'BAR=FOO'] }) }
   it { is_expected.to allow_value({ 'EnvironmentFile' => '/etc/sysconfig/foo' }) }
   it { is_expected.to allow_value({ 'EnvironmentFile' => '-/etc/sysconfig/foo' }) }
   it { is_expected.to allow_value({ 'EnvironmentFile' => ['/etc/sysconfig/foo', '-/etc/sysconfig/foo-bar'] }) }

--- a/types/unit/service.pp
+++ b/types/unit/service.pp
@@ -91,7 +91,7 @@ type Systemd::Unit::Service = Struct[
     Optional['NotifyAccess']              => Enum['none', 'default', 'main', 'exec',  'all'],
     Optional['OOMPolicy']                 => Enum['continue', 'stop','kill'],
     Optional['OOMScoreAdjust']            => Integer[-1000,1000],
-    Optional['Environment']               => String,
+    Optional['Environment']               => Variant[String[0],Array[String[1],1]],
     Optional['EnvironmentFile']           => Variant[
       Stdlib::Unixpath,Pattern[/-\/.+/],
       Array[Variant[Stdlib::Unixpath,Pattern[/-\/.+/]],1],


### PR DESCRIPTION
#### Pull Request (PR) description

It was previously impossible to set more than one environment variable:

e.g.

```puppet
systemd::manage_unit { 'test.service':
  unit_entry    => {
    'Description' => 'Bla',
  },
  service_entry => {
    'Type'        => 'oneshot',
    'Environment' => [
      'bla=foo',
      'bar=bla',
    ],
    'ExecStart'   => '/usr/bin/true',
  },
  enable        => false,
  active        => false,
}
```

#### This Pull Request (PR) fixes the following issues

Fixes #404

