### PR TITLE
Add loginctl_linger_users fact

### DIFF
--- a/lib/facter/loginctl_linger_users.rb
+++ b/lib/facter/loginctl_linger_users.rb
@@ -1,0 +1,20 @@
+# frozen_string_literal: true
+
+# https://puppet.com/docs/puppet/latest/fact_overview.html
+Facter.add(:loginctl_linger_users) do
+  confine kernel: 'Linux'
+
+  setcode do
+    users = []
+
+    if Dir.exist?('/var/lib/systemd/linger')
+      users = Dir.entries('/var/lib/systemd/linger')
+      users.delete('.')
+      users.delete('..')
+    end
+
+    users.append('root') unless users.include?('root') # root should always linger
+
+    users
+  end
+end

--- a/spec/unit/facter/loginctl_linger_users_spec.rb
+++ b/spec/unit/facter/loginctl_linger_users_spec.rb
@@ -1,0 +1,30 @@
+# frozen_string_literal: true
+
+require 'spec_helper'
+
+describe Facter.fact(:loginctl_linger_users) do
+  before do
+    Facter.clear
+  end
+
+  describe 'loginctl_linger_users' do
+    context 'returns root when nothing is present' do
+      it do
+        allow(Dir).to receive(:exist?).and_return(false)
+        allow(Dir).to receive(:exist?).with('/var/lib/systemd/linger').and_return(false)
+
+        expect(Facter.value(:loginctl_linger_users)).to eq(['root'])
+      end
+    end
+
+    context 'returns list with root others are present' do
+      it do
+        allow(Dir).to receive(:exist?).and_return(false)
+        allow(Dir).to receive(:exist?).with('/var/lib/systemd/linger').and_return(true)
+        allow(Dir).to receive(:entries).with('/var/lib/systemd/linger').and_return(%w[. .. abc test])
+
+        expect(Facter.value(:loginctl_linger_users)).to eq(%w[abc test root])
+      end
+    end
+  end
+end


### PR DESCRIPTION
<!--
Thank you for contributing to this project!

- This project has a Contributor Code of Conduct: https://voxpupuli.org/coc/
- Please check that here is no existing issue or PR that addresses your problem.
- Our vulnerabilities reporting process is at https://voxpupuli.org/security/

-->
#### Pull Request (PR) description
Add a fact listing users with linger enabled.

As near as I can tell from the systemd source, `root` is always able to linger even it not setup explicitly.

#### This Pull Request (PR) fixes the following issues
<!--
Replace this comment with the list of issues or n/a.
Use format:
Fixes #123
Fixes #124
-->
