### PR TITLE
Support `StartLimitIntervalSec` and  `StartLimitBurst`

### DIFF
--- a/REFERENCE.md
+++ b/REFERENCE.md
@@ -2646,6 +2646,8 @@ Struct[{
     Optional['ConditionPathExists']       => Variant[Enum[''],Stdlib::Unixpath,Pattern[/^!.*$/],Array[Variant[Enum[''],Stdlib::Unixpath,Pattern[/^!.*$/]],1]],
     Optional['ConditionPathIsDirectory']  => Variant[Enum[''],Stdlib::Unixpath,Pattern[/^!.*$/],Array[Variant[Enum[''],Stdlib::Unixpath,Pattern[/^!.*$/]],1]],
     Optional['ConditionPathIsMountPoint'] => Variant[Enum[''],Stdlib::Unixpath,Pattern[/^!.*$/],Array[Variant[Enum[''],Stdlib::Unixpath,Pattern[/^!.*$/]],1]],
+    Optional['StartLimitIntervalSec']     => String[1],
+    Optional['StartLimitBurst']           => Integer[1],
   }]
 ```
 

--- a/spec/type_aliases/systemd_unit_unit_spec.rb
+++ b/spec/type_aliases/systemd_unit_unit_spec.rb
@@ -114,4 +114,9 @@ describe 'Systemd::Unit::Unit' do
   it { is_expected.not_to allow_value({ 'RequiresMountsFor' => 'not/an/absolute/path' }) }
   it { is_expected.not_to allow_value({ 'RequiresMountsFor' => ['not/a/path'] }) }
   it { is_expected.not_to allow_value({ 'RequiresMountsFor' => [] }) }
+
+  it { is_expected.to allow_value({ 'StartLimitIntervalSec' => '12 hours' }) }
+  it { is_expected.to allow_value({ 'StartLimitIntervalSec' => 'infinity' }) }
+  it { is_expected.to allow_value({ 'StartLimitBurst' => 5 }) }
+  it { is_expected.not_to allow_value({ 'StartLimitBurst' => '5' }) }
 end

--- a/types/unit/unit.pp
+++ b/types/unit/unit.pp
@@ -42,5 +42,7 @@ type Systemd::Unit::Unit = Struct[
     Optional['ConditionPathExists']       => Variant[Enum[''],Stdlib::Unixpath,Pattern[/^!.*$/],Array[Variant[Enum[''],Stdlib::Unixpath,Pattern[/^!.*$/]],1]],
     Optional['ConditionPathIsDirectory']  => Variant[Enum[''],Stdlib::Unixpath,Pattern[/^!.*$/],Array[Variant[Enum[''],Stdlib::Unixpath,Pattern[/^!.*$/]],1]],
     Optional['ConditionPathIsMountPoint'] => Variant[Enum[''],Stdlib::Unixpath,Pattern[/^!.*$/],Array[Variant[Enum[''],Stdlib::Unixpath,Pattern[/^!.*$/]],1]],
+    Optional['StartLimitIntervalSec']     => String[1],
+    Optional['StartLimitBurst']           => Integer[1],
   }
 ]


### PR DESCRIPTION
#### Pull Request (PR) description

Allow `StartLimitIntervalSec` and `StartLimitBurst` to be set in the `[unit]` section of a managed drop or unit file.

https://www.freedesktop.org/software/systemd/man/latest/systemd.unit.html#StartLimitIntervalSec=interval
