### PR TITLE
Add parameter to manage /etc/udev/rules.d directory

### DIFF
--- a/REFERENCE.md
+++ b/REFERENCE.md
@@ -144,6 +144,7 @@ The following parameters are available in the `systemd` class:
 * [`manage_oomd`](#-systemd--manage_oomd)
 * [`oomd_ensure`](#-systemd--oomd_ensure)
 * [`oomd_settings`](#-systemd--oomd_settings)
+* [`udev_purge_rules`](#-systemd--udev_purge_rules)
 
 ##### <a name="-systemd--default_target"></a>`default_target`
 
@@ -601,6 +602,14 @@ Data type: `Systemd::OomdSettings`
 Hash of systemd-oomd configurations for oomd.conf
 
 Default value: `{}`
+
+##### <a name="-systemd--udev_purge_rules"></a>`udev_purge_rules`
+
+Data type: `Boolean`
+
+Toggle if unmanaged files in /etc/udev/rules.d should be purged if manage_udevd is enabled
+
+Default value: `false`
 
 ### <a name="systemd--tmpfiles"></a>`systemd::tmpfiles`
 

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -183,6 +183,8 @@
 # @param oomd_settings
 #   Hash of systemd-oomd configurations for oomd.conf
 #
+# @param udev_purge_rules
+#   Toggle if unmanaged files in /etc/udev/rules.d should be purged if manage_udevd is enabled
 class systemd (
   Optional[Pattern['^.+\.target$']]                   $default_target = undef,
   Hash[String,String]                                 $accounting = {},
@@ -239,6 +241,7 @@ class systemd (
   Boolean                                             $manage_oomd = false,
   Enum['stopped','running']                           $oomd_ensure = 'running',
   Systemd::OomdSettings                               $oomd_settings = {},
+  Boolean                                             $udev_purge_rules = false,
 ) {
   contain systemd::install
 

--- a/manifests/udevd.pp
+++ b/manifests/udevd.pp
@@ -9,6 +9,12 @@ class systemd::udevd {
     enable => true,
   }
 
+  file { '/etc/udev/rules.d':
+    ensure  => directory,
+    purge   => $systemd::udev_purge_rules,
+    recurse => true,
+  }
+
   file { '/etc/udev/udev.conf':
     ensure  => 'file',
     owner   => 'root',

--- a/spec/classes/init_spec.rb
+++ b/spec/classes/init_spec.rb
@@ -498,6 +498,7 @@ describe 'systemd' do
           it { is_expected.to compile.with_all_deps }
           it { is_expected.not_to contain_service('systemd-udevd') }
           it { is_expected.not_to contain_file('/etc/udev/udev.conf') }
+          it { is_expected.not_to contain_file('/etc/udev/rules.d') }
         end
 
         context 'when working with udevd and no custom rules' do
@@ -534,6 +535,8 @@ describe 'systemd' do
               with_content(%r{^resolve_names=early$}).
               with_content(%r{^timeout_signal=SIGKILL$})
           }
+
+          it { is_expected.to contain_file('/etc/udev/rules.d').with_ensure('directory').with_purge(false) }
         end
 
         context 'when working with udevd and a rule set' do
@@ -555,6 +558,18 @@ describe 'systemd' do
               } },
 
             }
+          end
+
+          context 'when enabling udevd management and rule purging' do
+            let(:params) do
+              {
+                manage_udevd: true,
+                udev_purge_rules: true,
+              }
+            end
+
+            it { is_expected.to compile.with_all_deps }
+            it { is_expected.to contain_file('/etc/udev/rules.d').with_ensure('directory').with_purge(true) }
           end
 
           it { is_expected.to compile.with_all_deps }


### PR DESCRIPTION
#### Pull Request (PR) description
Add a parameter that will purge all non managed files from `/etc/udev/rules.d directory`
Defaults to `false`
#### This Pull Request (PR) fixes the following issues
fixes #291