### PR TITLE
remove resolved settings from config when changed to `absent`

### DIFF
--- a/REFERENCE.md
+++ b/REFERENCE.md
@@ -294,17 +294,19 @@ Default value: `undef`
 
 ##### <a name="-systemd--dns_stub_listener"></a>`dns_stub_listener`
 
-Data type: `Optional[Variant[Boolean,Enum['udp','tcp']]]`
+Data type: `Optional[Variant[Boolean,Enum['udp','tcp','absent']]]`
 
 Takes a boolean argument or one of "udp" and "tcp".
+Setting it to `'absent'` will remove `DNSStubListener` existing entries from the configuration file
 
 Default value: `undef`
 
 ##### <a name="-systemd--dns_stub_listener_extra"></a>`dns_stub_listener_extra`
 
-Data type: `Optional[Array[String[1]]]`
+Data type: `Optional[Variant[Array[String[1]],Enum['absent']]]`
 
 Additional addresses for the DNS stub listener to listen on
+Setting it to `'absent'` will remove `DNSStubListenerExtra` existing entries from the configuration file
 
 Default value: `undef`
 

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -65,9 +65,11 @@
 #
 # @param dns_stub_listener
 #   Takes a boolean argument or one of "udp" and "tcp".
+#   Setting it to `'absent'` will remove `DNSStubListener` existing entries from the configuration file
 #
 # @param dns_stub_listener_extra
 #   Additional addresses for the DNS stub listener to listen on
+#   Setting it to `'absent'` will remove `DNSStubListenerExtra` existing entries from the configuration file
 #
 # @param manage_resolv_conf
 #   For when `manage_resolved` is `true` should the file `/etc/resolv.conf` be managed.
@@ -204,8 +206,8 @@ class systemd (
   Optional[Variant[Boolean,Enum['allow-downgrade']]]  $dnssec = undef,
   Variant[Boolean,Enum['yes', 'opportunistic', 'no']] $dnsovertls = false,
   Optional[Variant[Boolean,Enum['no-negative']]]      $cache = undef,
-  Optional[Variant[Boolean,Enum['udp','tcp']]]        $dns_stub_listener = undef,
-  Optional[Array[String[1]]] $dns_stub_listener_extra = undef,
+  Optional[Variant[Boolean,Enum['udp','tcp','absent']]]  $dns_stub_listener = undef,
+  Optional[Variant[Array[String[1]],Enum['absent']]] $dns_stub_listener_extra = undef,
   Boolean                                             $manage_resolv_conf = true,
   Boolean                                             $use_stub_resolver = false,
   Boolean                                             $manage_networkd = false,

--- a/manifests/resolved.pp
+++ b/manifests/resolved.pp
@@ -57,9 +57,9 @@ class systemd::resolved (
   Optional[Variant[Boolean,Enum['resolve']]] $multicast_dns          = $systemd::multicast_dns,
   Optional[Variant[Boolean,Enum['allow-downgrade']]] $dnssec         = $systemd::dnssec,
   Optional[Variant[Boolean,Enum['yes', 'opportunistic', 'no']]] $dnsovertls = $systemd::dnsovertls,
-  Optional[Variant[Boolean,Enum['no-negative']]] $cache              = $systemd::cache,
-  Optional[Variant[Boolean,Enum['udp', 'tcp']]] $dns_stub_listener   = $systemd::dns_stub_listener,
-  Optional[Array[String[1]]] $dns_stub_listener_extra                = $systemd::dns_stub_listener_extra,
+  Optional[Variant[Boolean,Enum['no-negative']]] $cache               = $systemd::cache,
+  Optional[Variant[Boolean,Enum['udp', 'tcp','absent']]] $dns_stub_listener = $systemd::dns_stub_listener,
+  Optional[Variant[Array[String[1]],Enum['absent']]] $dns_stub_listener_extra = $systemd::dns_stub_listener_extra,
   Boolean $use_stub_resolver                                         = $systemd::use_stub_resolver,
 ) {
   assert_private()
@@ -239,9 +239,9 @@ class systemd::resolved (
     default => $dns_stub_listener,
   }
 
-  if $_dns_stub_listener {
+  if  $dns_stub_listener =~ String[1] {
     ini_setting { 'dns_stub_listener':
-      ensure  => 'present',
+      ensure  => stdlib::ensure($dns_stub_listener != 'absent'),
       value   => $_dns_stub_listener,
       setting => 'DNSStubListener',
       section => 'Resolve',
@@ -250,9 +250,9 @@ class systemd::resolved (
     }
   }
 
-  if $dns_stub_listener_extra {
+  if $dns_stub_listener_extra =~ NotUndef {
     ini_setting { 'dns_stub_listener_extra':
-      ensure  => 'present',
+      ensure  => stdlib::ensure($dns_stub_listener_extra != 'absent'),
       value   => $dns_stub_listener_extra,
       setting => 'DNSStubListenerExtra',
       section => 'Resolve',

--- a/spec/classes/init_spec.rb
+++ b/spec/classes/init_spec.rb
@@ -137,6 +137,36 @@ describe 'systemd' do
           it { is_expected.not_to contain_ini_setting('dns_stub_listener') }
         end
 
+        context 'when setting dns_stub_listener to absent' do
+          let(:params) do
+            {
+              manage_resolved: true,
+              dns: ['8.8.8.8', '8.8.4.4'],
+              fallback_dns: ['2001:4860:4860::8888', '2001:4860:4860::8844'],
+              dns_stub_listener: 'absent'
+            }
+          end
+
+          it { is_expected.to create_service('systemd-resolved').with_ensure('running') }
+          it { is_expected.to create_service('systemd-resolved').with_enable(true) }
+          it { is_expected.to contain_ini_setting('dns_stub_listener').with_ensure('absent') }
+        end
+
+        context 'when setting dns_stub_listener_extra to absent' do
+          let(:params) do
+            {
+              manage_resolved: true,
+              dns: ['8.8.8.8', '8.8.4.4'],
+              fallback_dns: ['2001:4860:4860::8888', '2001:4860:4860::8844'],
+              dns_stub_listener_extra: 'absent'
+            }
+          end
+
+          it { is_expected.to create_service('systemd-resolved').with_ensure('running') }
+          it { is_expected.to create_service('systemd-resolved').with_enable(true) }
+          it { is_expected.to contain_ini_setting('dns_stub_listener_extra').with_ensure('absent') }
+        end
+
         context 'when enabling resolved with DNS values (full)' do
           let(:params) do
             {
@@ -171,8 +201,13 @@ describe 'systemd' do
             )
           }
 
-          it { is_expected.to contain_ini_setting('dns_stub_listener') }
-          it { is_expected.to contain_ini_setting('dns_stub_listener_extra').with_value(['192.0.2.1', '2001:db8::1']) }
+          it { is_expected.to contain_ini_setting('dns_stub_listener').with_ensure('present') }
+
+          it {
+            is_expected.to contain_ini_setting('dns_stub_listener_extra').
+              with_value(['192.0.2.1', '2001:db8::1']).
+              with_ensure('present')
+          }
         end
 
         context 'when enabling resolved with no-negative cache variant' do


### PR DESCRIPTION
#### Pull Request (PR) description
When `dns_stub_listener` and `dns_stub_listener_extra` are changed from a value to `undef` they don't get removed from the config.

There is plenty more settings  here that could use the same treatment I guess

#### This Pull Request (PR) fixes the following issues
Fixes #397
