### PR TITLE
Avoid empty sections being created in unit files

### DIFF
--- a/REFERENCE.md
+++ b/REFERENCE.md
@@ -1847,35 +1847,35 @@ Default value: `undef`
 
 ##### <a name="-systemd--timer_wrapper--service_overrides"></a>`service_overrides`
 
-Data type: `Systemd::Unit::Service`
+Data type: `Optional[Systemd::Unit::Service]`
 
 override for the`[Service]` section of the service
 
-Default value: `{}`
+Default value: `undef`
 
 ##### <a name="-systemd--timer_wrapper--timer_overrides"></a>`timer_overrides`
 
-Data type: `Systemd::Unit::Timer`
+Data type: `Optional[Systemd::Unit::Timer]`
 
 override for the`[Timer]` section of the timer
 
-Default value: `{}`
+Default value: `undef`
 
 ##### <a name="-systemd--timer_wrapper--service_unit_overrides"></a>`service_unit_overrides`
 
-Data type: `Systemd::Unit::Unit`
+Data type: `Optional[Systemd::Unit::Unit]`
 
 override for the`[Unit]` section of the service
 
-Default value: `{}`
+Default value: `undef`
 
 ##### <a name="-systemd--timer_wrapper--timer_unit_overrides"></a>`timer_unit_overrides`
 
-Data type: `Systemd::Unit::Unit`
+Data type: `Optional[Systemd::Unit::Unit]`
 
 override for the `[Unit]` section of the timer
 
-Default value: `{}`
+Default value: `undef`
 
 ### <a name="systemd--tmpfile"></a>`systemd::tmpfile`
 

--- a/manifests/manage_dropin.pp
+++ b/manifests/manage_dropin.pp
@@ -98,6 +98,14 @@ define systemd::manage_dropin (
   Optional[Systemd::Unit::Path]    $path_entry              = undef,
   Optional[Systemd::Unit::Socket]  $socket_entry            = undef,
 ) {
+  if $ensure != 'absent' {
+    ['install_entry', 'unit_entry', 'slice_entry', 'service_entry', 'timer_entry', 'path_entry', 'socket_entry'].each |$_entry| {
+      assert_type(Variant[Hash[String[1],Any,1],Undef],getvar($_entry)) | $_expected, $_actual | {
+        fail("The ${_entry} parameter should be \"${_expected}\", and not \"${_actual}\". At least one directive must be set if \"${_entry}\" it is set")
+      }
+    }
+  }
+
   if $timer_entry and $unit !~ Pattern['^[^/]+\.timer'] {
     fail("Systemd::Manage_dropin[${name}]: for unit ${unit} timer_entry is only valid for timer units")
   }

--- a/manifests/manage_unit.pp
+++ b/manifests/manage_unit.pp
@@ -118,6 +118,15 @@ define systemd::manage_unit (
 ) {
   assert_type(Systemd::Unit, $name)
 
+  # Verify at least one directive is set
+  if $ensure != 'absent' {
+    ['install_entry', 'unit_entry', 'slice_entry', 'service_entry', 'timer_entry', 'path_entry', 'socket_entry'].each |$_entry| {
+      assert_type(Variant[Hash[String[1],Any,1],Undef],getvar($_entry)) | $_expected, $_actual | {
+        fail("The \"${_entry}\" parameter should be \"${_expected}\", and not \"${_actual}\". At least one directive must be set if \"${_entry}\" it is set")
+      }
+    }
+  }
+
   if $timer_entry and $name !~ Pattern['^[^/]+\.timer'] {
     fail("Systemd::Manage_unit[${name}]: timer_entry is only valid for timer units")
   }

--- a/spec/defines/manage_dropin_spec.rb
+++ b/spec/defines/manage_dropin_spec.rb
@@ -20,6 +20,14 @@ describe 'systemd::manage_dropin' do
           it { is_expected.to compile.with_all_deps }
           it { is_expected.to contain_systemd__dropin_file('foobar.conf').with_content(%r{^# Deployed with puppet$}) }
 
+          context 'with an empty slice entry' do
+            let(:params) do
+              super().merge(slice_entry: {})
+            end
+
+            it { is_expected.to compile.and_raise_error(%r{one directive must be set if "slice_entry" it is set}) }
+          end
+
           context 'setting some parameters simply' do
             let(:params) do
               super().merge(

--- a/spec/defines/manage_unit_spec.rb
+++ b/spec/defines/manage_unit_spec.rb
@@ -46,6 +46,17 @@ describe 'systemd::manage_unit' do
               without_content(%r{^\[Slice\]$})
           }
 
+          context 'with an empty service_entry' do
+            let(:params) do
+              {
+                ensure: 'present',
+                service_entry: {},
+              }
+            end
+
+            it { is_expected.to compile.and_raise_error(%r{one directive must be set if "service_entry" it is set}) }
+          end
+
           context 'with no service_entry' do
             let(:params) do
               {


### PR DESCRIPTION
#### Pull Request (PR) description

Before this patch:

```puppet
systemd::manage_unut{'myserive.service':
  ensure => 'present',
  service_entry => {},
  install_entry => {},
}
```
would create a unit file:

```
[Service]

[Install]
```

Insist that at least one directive is present per  defined section if `ensure => present`.

In particular `systemd::timer_wrapper` was creating empty sections often.