### PR TITLE
Don't allow ensure=file anymore for systemd::unit_file

### DIFF
--- a/REFERENCE.md
+++ b/REFERENCE.md
@@ -2073,7 +2073,7 @@ The target unit file to create
 
 ##### <a name="-systemd--unit_file--ensure"></a>`ensure`
 
-Data type: `Enum['present', 'absent', 'file']`
+Data type: `Enum['present', 'absent']`
 
 The state of the unit file to ensure
 

--- a/manifests/unit_file.pp
+++ b/manifests/unit_file.pp
@@ -66,7 +66,7 @@
 #   }
 #
 define systemd::unit_file (
-  Enum['present', 'absent', 'file']        $ensure    = 'present',
+  Enum['present', 'absent']                $ensure    = 'present',
   Stdlib::Absolutepath                     $path      = '/etc/systemd/system',
   Optional[Variant[String, Sensitive[String], Deferred]] $content = undef,
   Optional[String]                         $source    = undef,


### PR DESCRIPTION
<!--
Thank you for contributing to this project!

- This project has a Contributor Code of Conduct: https://voxpupuli.org/coc/
- Please check that here is no existing issue or PR that addresses your problem.
- Our vulnerabilities reporting process is at https://voxpupuli.org/security/

-->
#### Pull Request (PR) description
@cocker-cc correctly mentioned in
https://github.com/voxpupuli/puppet-systemd/commit/7f63dfa49850a860b24a93874fe5c5f4430f9edc#commitcomment-139614892 that after #405 `ensure=file` breaks due to `stdlib::ensure` not being able to handle that. As `file` is any way only a synonym for `present`, let's just remove it from the possible values.

#### This Pull Request (PR) fixes the following issues
https://github.com/voxpupuli/puppet-systemd/commit/7f63dfa49850a860b24a93874fe5c5f4430f9edc#commitcomment-139614892