### PR TITLE
Create manage_unit, manage_dropin types from hiera

### DIFF
--- a/README.md
+++ b/README.md
@@ -82,6 +82,17 @@ systemd::manage_unit { 'myrunner.service':
 The parameters `unit_entry`, `service_entry` and `install_entry` populate the
 `[Unit]`, `[Service]` and `[Install]` sections of the generated unit file.
 
+Similarly units can be created from hiera yaml files
+
+```yaml
+systemd::manage_units:
+  myservice.service:
+    unit_entry:
+      Description: My Customisation
+    service_entry:
+      CPUWeight: 2000
+```
+
 ### drop-in files
 
 Drop-in files are used to add or alter settings of a unit without modifying the
@@ -139,6 +150,20 @@ systemd::manage_dropin { 'myconf.conf':
     'ExecStart' => ['', '/usr/bin/doit.sh'],
   },
 }
+```
+
+Dropins can also be created similarly via yaml
+
+```yaml
+systemd::manage_dropins:
+  myconf.conf:
+    ensure: present
+    unit: myservice.service
+    service_entry:
+      Type: oneshot
+      ExecStart:
+        - ''
+        - '/usr/bin/doit.sh'
 ```
 
 The filename of the drop in. The full path is determined using the path, unit and this filename.

--- a/REFERENCE.md
+++ b/REFERENCE.md
@@ -133,6 +133,8 @@ The following parameters are available in the `systemd` class:
 * [`logind_settings`](#-systemd--logind_settings)
 * [`loginctl_users`](#-systemd--loginctl_users)
 * [`dropin_files`](#-systemd--dropin_files)
+* [`manage_units`](#-systemd--manage_units)
+* [`manage_dropins`](#-systemd--manage_dropins)
 * [`manage_all_network_files`](#-systemd--manage_all_network_files)
 * [`network_path`](#-systemd--network_path)
 * [`manage_accounting`](#-systemd--manage_accounting)
@@ -511,7 +513,23 @@ Default value: `{}`
 
 Data type: `Hash`
 
-Configure dropin files via hiera with factory pattern
+Configure dropin files via hiera and `systemd::dropin_file` with factory pattern
+
+Default value: `{}`
+
+##### <a name="-systemd--manage_units"></a>`manage_units`
+
+Data type: `Hash[String[1], Hash[String[1], Any]]`
+
+Configure units via hiera and `systemd::manage_unit` with factory pattern
+
+Default value: `{}`
+
+##### <a name="-systemd--manage_dropins"></a>`manage_dropins`
+
+Data type: `Hash[String[1], Hash[String[1], Any]]`
+
+Configure dropin files via hiera and `systemd::manage_dropin` with factory pattern
 
 Default value: `{}`
 

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -149,7 +149,13 @@
 #   `loginctl_user`.
 #
 # @param dropin_files
-#   Configure dropin files via hiera with factory pattern
+#   Configure dropin files via hiera and `systemd::dropin_file` with factory pattern
+#
+# @param manage_units
+#   Configure units via hiera and `systemd::manage_unit` with factory pattern
+#
+# @param manage_dropins
+#   Configure dropin files via hiera and `systemd::manage_dropin` with factory pattern
 #
 # @param manage_all_network_files
 #
@@ -234,6 +240,8 @@ class systemd (
   Stdlib::Absolutepath                                $network_path = '/etc/systemd/network',
   Hash                                                $loginctl_users = {},
   Hash                                                $dropin_files = {},
+  Hash[String[1], Hash[String[1], Any]]               $manage_units = {},
+  Hash[String[1], Hash[String[1], Any]]               $manage_dropins = {},
   Hash                                                $udev_rules = {},
   Boolean                                             $manage_coredump = false,
   Systemd::CoredumpSettings                           $coredump_settings = {},
@@ -329,6 +337,18 @@ class systemd (
 
   $dropin_files.each |$name, $resource| {
     systemd::dropin_file { $name:
+      * => $resource,
+    }
+  }
+
+  $manage_units.each |$name, $resource| {
+    systemd::manage_unit { $name:
+      * => $resource,
+    }
+  }
+
+  $manage_dropins.each |$name, $resource| {
+    systemd::manage_dropin { $name:
       * => $resource,
     }
   }

--- a/spec/classes/init_spec.rb
+++ b/spec/classes/init_spec.rb
@@ -764,7 +764,7 @@ describe 'systemd' do
           let :params do
             {
               manage_networkd: true,
-              manage_all_network_files: true
+              manage_all_network_files: true,
             }
           end
 

--- a/spec/classes/init_spec.rb
+++ b/spec/classes/init_spec.rb
@@ -709,6 +709,57 @@ describe 'systemd' do
           it { is_expected.to contain_systemd__dropin_file('my-foo.conf').with_content('[Service]\nReadWritePaths=/') }
         end
 
+        context 'when passing manage_units' do
+          let(:params) do
+            {
+              manage_units: {
+                'special.service' => {
+                  'ensure' => 'present',
+                  'unit_entry' => { 'Description' => 'My Special Unit' },
+                  'service_entry' => { 'TimeoutStartSec' => '100h' },
+                },
+              },
+            }
+          end
+
+          it {
+            is_expected.to contain_systemd__manage_unit('special.service').
+              with_ensure('present').
+              with_unit_entry({ 'Description' => 'My Special Unit' }).
+              with_service_entry({ 'TimeoutStartSec' => '100h' })
+          }
+        end
+
+        context 'when passing manage_dropins' do
+          let(:params) do
+            {
+              manage_dropins: {
+                'foo.conf' => {
+                  'unit' => 'special.slice',
+                  'slice_entry' => { 'CPUQuota' => '999%' },
+                },
+                'bar.conf' => {
+                  'unit' => 'special.timer',
+                  'timer_entry' => { 'OnCalendar' => ['', 'Daily'] },
+                },
+
+              },
+            }
+          end
+
+          it {
+            is_expected.to contain_systemd__manage_dropin('foo.conf').
+              with_unit('special.slice').
+              with_slice_entry({ 'CPUQuota' => '999%' })
+          }
+
+          it {
+            is_expected.to contain_systemd__manage_dropin('bar.conf').
+              with_unit('special.timer').
+              with_timer_entry({ 'OnCalendar' => ['', 'Daily'] })
+          }
+        end
+
         context 'with managed networkd directory' do
           let :params do
             {


### PR DESCRIPTION
#### Pull Request (PR) description

Units and dropins can now be created from hiera records:

e.g.

```yaml
systemd::manage_dropins:
  myconf.conf:
    ensure: present
    unit: myservice.service
    service_entry:
      Type: oneshot
      ExecStart:
        - ''
        - '/usr/bin/doit.sh'

systemd::manage_units:
  myservice.service:
    unit_entry:
      Description: My Customisation
    service_entry:
      CPUWeight: 2000
```
#### This Pull Request (PR) fixes the following issues
Fixes #435

