### PR TITLE
`init`: `service_limits` param: don't refer to `create_resources`

### DIFF
--- a/REFERENCE.md
+++ b/REFERENCE.md
@@ -160,8 +160,7 @@ Default value: `undef`
 
 Data type: `Hash[String[1],Hash[String[1], Any]]`
 
-May be passed a resource hash suitable for passing directly into the
-``create_resources()`` function as called on ``systemd::service_limits``
+Hash of `systemd::service_limits` resources
 
 Default value: `{}`
 

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -6,8 +6,7 @@
 #   The default systemd boot target, unmanaged if set to undef.
 #
 # @param service_limits
-#   May be passed a resource hash suitable for passing directly into the
-#   ``create_resources()`` function as called on ``systemd::service_limits``
+#   Hash of `systemd::service_limits` resources
 #
 # @param networks
 #   Hash of `systemd::network` resources


### PR DESCRIPTION
The code doesn't actually use `create_resources` anymore. This commit makes the doc string consistent with the other similar parameters.