### PR TITLE
Support reload of instances of systemd --user

### DIFF
--- a/REFERENCE.md
+++ b/REFERENCE.md
@@ -658,12 +658,35 @@ Default value: `['create']`
 
 Run systemctl daemon-reload
 
+#### Examples
+
+##### Force reload the system systemd
+
+```puppet
+notify{ 'fake event to notify from':
+  notify => Systemd::Daemon_reload['special']
+}
+systemd::daemon_reload{ 'special': }
+```
+
+##### Force reload a systemd --user
+
+```puppet
+notify{ 'fake event to notify from':
+  notify => Systemd::Daemon_reload['steve_user']
+}
+systemd::daemon_reload{ 'steve_user':
+  user => 'steve',
+}
+```
+
 #### Parameters
 
 The following parameters are available in the `systemd::daemon_reload` defined type:
 
 * [`name`](#-systemd--daemon_reload--name)
 * [`enable`](#-systemd--daemon_reload--enable)
+* [`user`](#-systemd--daemon_reload--user)
 
 ##### <a name="-systemd--daemon_reload--name"></a>`name`
 
@@ -674,10 +697,18 @@ A globally unique name for the resource
 Data type: `Boolean`
 
 Enable the reload exec
-
 * Added in case users want to disable the reload globally using a resource collector
 
 Default value: `true`
+
+##### <a name="-systemd--daemon_reload--user"></a>`user`
+
+Data type: `Optional[String[1]]`
+
+Specify user name of `systemd --user` to reload. This not supported **below** Redhat 9,
+Ubuntu 22.04 or Debian 12.
+
+Default value: `undef`
 
 ### <a name="systemd--dropin_file"></a>`systemd::dropin_file`
 

--- a/manifests/daemon_reload.pp
+++ b/manifests/daemon_reload.pp
@@ -7,15 +7,49 @@
 #
 # @param enable
 #   Enable the reload exec
-#
 #   * Added in case users want to disable the reload globally using a resource collector
+#
+# @param user
+#   Specify user name of `systemd --user` to reload. This not supported **below** Redhat 9,
+#   Ubuntu 22.04 or Debian 12.
+#
+# @example Force reload the system systemd
+#   notify{ 'fake event to notify from':
+#     notify => Systemd::Daemon_reload['special']
+#   }
+#   systemd::daemon_reload{ 'special': }
+#
+# @example Force reload a systemd --user
+#   notify{ 'fake event to notify from':
+#     notify => Systemd::Daemon_reload['steve_user']
+#   }
+#   systemd::daemon_reload{ 'steve_user':
+#     user => 'steve',
+#   }
 #
 define systemd::daemon_reload (
   Boolean $enable = true,
+  Optional[String[1]] $user = undef,
 ) {
+  include systemd
+
   if $enable {
-    exec { "${module_name}-${name}-systemctl-daemon-reload":
-      command     => 'systemctl daemon-reload',
+    if $user {
+      if ($facts['os']['family'] == 'RedHat' and versioncmp($facts['os']['release']['major'],'9') < 0 ) or
+      ($facts['os']['name'] == 'Debian' and versioncmp($facts['os']['release']['major'],'12') < 0 ) or
+      ($facts['os']['name'] == 'Ubuntu' and versioncmp($facts['os']['release']['major'],'22.04') < 0 ) {
+        fail('systemd::daemon_reload_for a user is not supported below RedHat 9, Debian 12 or Ubuntu 22.04')
+      }
+
+      $_title   = "${module_name}-${name}-systemctl-user-${user}-daemon-reload"
+      $_command = ['systemd-run', '--pipe', '--wait', '--user', '--machine', "${user}@.host", 'systemctl', '--user', 'daemon-reload']
+    } else {
+      $_title   = "${module_name}-${name}-systemctl-daemon-reload"
+      $_command = ['systemctl', 'daemon-reload']
+    }
+
+    exec { $_title:
+      command     => $_command,
       refreshonly => true,
       path        => $facts['path'],
     }

--- a/metadata.json
+++ b/metadata.json
@@ -100,7 +100,7 @@
   "requirements": [
     {
       "name": "puppet",
-      "version_requirement": ">= 7.0.0 < 9.0.0"
+      "version_requirement": ">= 7.9.0 < 9.0.0"
     }
   ]
 }


### PR DESCRIPTION
#### Pull Request (PR) description

This change increased the minimum required Puppet version to 6.24.0 or 7.9.0 [PUP-5704](https://puppet.atlassian.net/browse/PUP-5704) to support arrays to the command attribute of the exec type.

Support the calling the `systemd --user daemon-reload` for a particular user.

Example run:
```puppet
notify{'junk':
 notify => Systemd::Daemon_reload['user_foobar'],
}

systemd::daemon_reload{'user_steve':
  user => 'steve',
}
```

This results on a Fedora box:

```
Notice: /Stage[main]/Main/Notify[junk]/message: defined 'message' as 'junk'
Notice: /Stage[main]/Main/Systemd::Daemon_reload[user_steve]/Package[systemd-container]: Triggered 'refresh' from 1 event
Notice: /Stage[main]/Main/Systemd::Daemon_reload[user_steve]/Exec[systemd-user_steve-systemctl-user-steve-daemon-reload]: Triggered 'refresh' from 1 event
```
and a journal (debug on) for `user@1000.service` of

```
Mar 29 10:32:11 fedora systemd[2062]: Created slice background.slice - User Background Tasks Slice.
Mar 29 10:32:11 fedora systemd[2062]: Starting systemd-tmpfiles-clean.service - Cleanup of User's Temporary Files and Directories...
Mar 29 10:32:11 fedora systemd[2062]: Reloading requested from client PID 4379 ('systemctl')...
Mar 29 10:32:11 fedora systemd[2062]: Reloading...
Mar 29 10:32:11 fedora systemd[2062]: Reloading finished in 179 ms.
Mar 29 10:32:11 fedora systemd[2062]: Finished systemd-tmpfiles-clean.service - Cleanup of User's Temporary Files and Directories.
```

Only recent versions of `systemd-run` support the `--machine` option or actually manage to connect to DBUS.



