### PR TITLE
New parameters to manage systemd-nspawn

### DIFF
--- a/REFERENCE.md
+++ b/REFERENCE.md
@@ -98,6 +98,8 @@ The following parameters are available in the `systemd` class:
 * [`manage_resolved`](#-systemd--manage_resolved)
 * [`resolved_ensure`](#-systemd--resolved_ensure)
 * [`resolved_package`](#-systemd--resolved_package)
+* [`manage_nspawn`](#-systemd--manage_nspawn)
+* [`nspawn_package`](#-systemd--nspawn_package)
 * [`dns`](#-systemd--dns)
 * [`fallback_dns`](#-systemd--fallback_dns)
 * [`domains`](#-systemd--domains)
@@ -219,6 +221,23 @@ Default value: `'running'`
 Data type: `Optional[Enum['systemd-resolved']]`
 
 The name of a systemd sub package needed for systemd-resolved if one needs to be installed.
+
+Default value: `undef`
+
+##### <a name="-systemd--manage_nspawn"></a>`manage_nspawn`
+
+Data type: `Boolean`
+
+Manage the systemd-nspawn@service and machinectl subsystem.
+
+Default value: `false`
+
+##### <a name="-systemd--nspawn_package"></a>`nspawn_package`
+
+Data type: `Optional[Enum['systemd-container']]`
+
+The name of a systemd sub package needed for the nspawn tools machinectl and
+systemd-nspawn if one needs to be installed.
 
 Default value: `undef`
 

--- a/data/Debian-family.yaml
+++ b/data/Debian-family.yaml
@@ -1,3 +1,2 @@
 ---
-systemd::networkd_package: systemd-networkd
 systemd::nspawn_package: 'systemd-container'

--- a/data/RedHat-family-7.yaml
+++ b/data/RedHat-family-7.yaml
@@ -1,5 +1,6 @@
 ---
 systemd::resolved_package: 'systemd-resolved'
+systemd::nspawn_package: ~
 
 systemd::accounting:
   DefaultCPUAccounting: 'yes'

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -31,6 +31,13 @@
 # @param resolved_package
 #   The name of a systemd sub package needed for systemd-resolved if one needs to be installed.
 #
+# @param manage_nspawn
+#   Manage the systemd-nspawn@service and machinectl subsystem.
+#
+# @param nspawn_package
+#   The name of a systemd sub package needed for the nspawn tools machinectl and
+#   systemd-nspawn if one needs to be installed.
+#
 # @param dns
 #   A space-separated list of IPv4 and IPv6 addresses to use as system DNS servers.
 #   DNS requests are sent to one of the listed DNS servers in parallel to suitable
@@ -243,6 +250,8 @@ class systemd (
   Stdlib::CreateResources                             $manage_dropins = {},
   Stdlib::CreateResources                             $udev_rules = {},
   Boolean                                             $manage_coredump = false,
+  Boolean                                             $manage_nspawn = false,
+  Optional[Enum['systemd-container']]                 $nspawn_package = undef,
   Systemd::CoredumpSettings                           $coredump_settings = {},
   Boolean                                             $coredump_backtrace = false,
   Boolean                                             $manage_oomd = false,

--- a/manifests/install.pp
+++ b/manifests/install.pp
@@ -19,4 +19,10 @@ class systemd::install {
       ensure => present,
     }
   }
+
+  if $systemd::manage_nspawn and $systemd::nspawn_package {
+    package { $systemd::nspawn_package:
+      ensure => present,
+    }
+  }
 }

--- a/spec/acceptance/nspwan_spec.rb
+++ b/spec/acceptance/nspwan_spec.rb
@@ -1,0 +1,26 @@
+# frozen_string_literal: true
+
+require 'spec_helper_acceptance'
+
+describe 'systemd with manage_nspawn true' do
+  machinectl = (fact('os.name') == 'Debian') && %w[10 11].include?(fact('os.release.major')) ? '/bin/machinectl' : '/usr/bin/machinectl'
+
+  context 'configure nspawn' do
+    let(:manifest) do
+      <<~PUPPET
+        class { 'systemd':
+          manage_nspawn => true,
+        }
+      PUPPET
+    end
+
+    it 'works idempotently with no errors' do
+      apply_manifest(manifest, catch_failures: true)
+      apply_manifest(manifest, catch_changes: true)
+    end
+
+    describe file(machinectl) do
+      it { is_expected.to be_file }
+    end
+  end
+end

--- a/spec/classes/init_spec.rb
+++ b/spec/classes/init_spec.rb
@@ -20,6 +20,7 @@ describe 'systemd' do
         it { is_expected.not_to contain_package('systemd-networkd') }
         it { is_expected.not_to contain_package('systemd-timesyncd') }
         it { is_expected.not_to contain_package('systemd-resolved') }
+        it { is_expected.not_to contain_package('systemd-container') }
         it { is_expected.not_to contain_class('systemd::coredump') }
         it { is_expected.not_to contain_class('systemd::oomd') }
         it { is_expected.not_to contain_exec('systemctl set-default multi-user.target') }
@@ -277,6 +278,28 @@ describe 'systemd' do
               value: 10
             )
           }
+        end
+
+        context 'when enabling nspawn' do
+          let(:params) do
+            {
+              manage_nspawn: true,
+            }
+          end
+
+          case facts[:os]['family']
+          when 'RedHat'
+            case facts[:os]['release']['major']
+            when '7'
+              it { is_expected.not_to contain_package('systemd-container') } # rubocop:disable RSpec/RepeatedExample
+            else
+              it { is_expected.to contain_package('systemd-container').with_ensure('present') } # rubocop:disable RSpec/RepeatedExample
+            end
+          when 'Debian'
+            it { is_expected.to contain_package('systemd-container').with_ensure('present') } # rubocop:disable RSpec/RepeatedExample
+          else
+            it { is_expected.not_to contain_package('systemd-container') } # rubocop:disable RSpec/RepeatedExample
+          end
         end
 
         context 'when enabling timesyncd' do


### PR DESCRIPTION
#### Pull Request (PR) description

New parameters `systemd::manage_nspawn` defaulting to `false`, if `true` it will ensure that the `machinectl` and `systemd-nspawn` commands are available.

When `true` the systemd_internal_services fact will be populated.

```
facter -p systemd_internal_services
{
  systemd-nspawn@.service => "disabled",
}
```
