### PR TITLE
Drop EoL Debian 10 support

### DIFF
--- a/data/Debian-10.yaml
+++ b/data/Debian-10.yaml
@@ -1,8 +1,0 @@
----
-systemd::accounting:
-  DefaultCPUAccounting: 'yes'
-  DefaultIOAccounting: 'yes'
-  DefaultIPAccounting: 'yes'
-  DefaultBlockIOAccounting: 'yes'
-  DefaultMemoryAccounting: 'yes'
-  DefaultTasksAccounting: 'yes'

--- a/metadata.json
+++ b/metadata.json
@@ -21,7 +21,6 @@
     {
       "operatingsystem": "Debian",
       "operatingsystemrelease": [
-        "10",
         "11",
         "12"
       ]

--- a/spec/classes/init_spec.rb
+++ b/spec/classes/init_spec.rb
@@ -316,7 +316,7 @@ describe 'systemd' do
           it { is_expected.not_to create_service('systemd-networkd').with_ensure('running') }
           it { is_expected.not_to create_service('systemd-networkd').with_enable(true) }
 
-          if (facts[:os]['name'] == 'Ubuntu' && Puppet::Util::Package.versioncmp(facts[:os]['release']['full'], '20.04') >= 0) || (facts[:os]['name'] == 'Debian' && Puppet::Util::Package.versioncmp(facts[:os]['release']['major'], '11') >= 0)
+          if (facts[:os]['name'] == 'Ubuntu' && Puppet::Util::Package.versioncmp(facts[:os]['release']['full'], '20.04') >= 0) || (facts[:os]['name'] == 'Debian')
             it { is_expected.to contain_package('systemd-timesyncd') }
           else
             it { is_expected.not_to contain_package('systemd-timesyncd') }

--- a/spec/defines/daemon_reload_spec.rb
+++ b/spec/defines/daemon_reload_spec.rb
@@ -24,8 +24,7 @@ describe 'systemd::daemon_reload' do
             end
 
             case [facts[:os]['name'], facts[:os]['family'], facts[:os]['release']['major']]
-            when %w[Debian Debian 10],
-              %w[Debian Debian 11],
+            when %w[Debian Debian 11],
               ['Ubuntu', 'Debian', '20.04'],
               %w[VirtuozzoLinux RedHat 7],
               %w[AlmaLinux RedHat 8],


### PR DESCRIPTION
Debian 10 is dead upstream, we don't support it anymore.

<!--
Thank you for contributing to this project!

- This project has a Contributor Code of Conduct: https://voxpupuli.org/coc/
- Please check that here is no existing issue or PR that addresses your problem.
- Our vulnerabilities reporting process is at https://voxpupuli.org/security/

-->
#### Pull Request (PR) description
<!--
Replace this comment with a description of your pull request.
-->

#### This Pull Request (PR) fixes the following issues
<!--
Replace this comment with the list of issues or n/a.
Use format:
Fixes #123
Fixes #124
-->
