### PR TITLE
Correctly interpolate variables in service_limits

### DIFF
--- a/manifests/service_limits.pp
+++ b/manifests/service_limits.pp
@@ -75,7 +75,7 @@ define systemd::service_limits (
     }.reduce | $_memo, $_value | { $_memo + $_value }
 
     deprecation("systemd::servicelimits - ${title}",'systemd::servicelimits is deprecated, use systemd::manage_dropin')
-    systemd::manage_dropin { '#{name}-90-limits.conf':
+    systemd::manage_dropin { "${name}-90-limits.conf":
       ensure                  => $ensure,
       unit                    => $name,
       filename                => '90-limits.conf',
@@ -86,7 +86,7 @@ define systemd::service_limits (
     }
   } else {
     deprecation("systemd::servicelimits ${title}",'systemd::servicelimits is deprecated, use systemd::dropin_file or systemd::manage_dropin')
-    systemd::dropin_file { '#{name}-90-limits.conf':
+    systemd::dropin_file { "${name}-90-limits.conf":
       ensure                  => $ensure,
       unit                    => $name,
       filename                => '90-limits.conf',


### PR DESCRIPTION
Fixes: 988d2c7db2db ("Deprecate `systemd::service_limits`")

This should be merged before https://github.com/voxpupuli/puppet-systemd/pull/447.