### PR TITLE
remove `systemd::escape` usage for `timer_wrapper`

### DIFF
--- a/manifests/timer_wrapper.pp
+++ b/manifests/timer_wrapper.pp
@@ -75,9 +75,8 @@ define systemd::timer_wrapper (
   }
 
   $service_ensure = $ensure ? { 'absent' => false,  default  => true, }
-  $unit_name = systemd::escape($title)
 
-  systemd::manage_unit { "${unit_name}.service":
+  systemd::manage_unit { "${title}.service":
     ensure        => $ensure,
     unit_entry    => $service_unit_overrides,
     service_entry => {
@@ -86,7 +85,7 @@ define systemd::timer_wrapper (
       'Type'      => 'oneshot',
     }.filter |$key, $val| { $val =~ NotUndef } + $service_overrides,
   }
-  systemd::manage_unit { "${unit_name}.timer":
+  systemd::manage_unit { "${title}.timer":
     ensure        => $ensure,
     unit_entry    => $timer_unit_overrides,
     timer_entry   => $_timer_spec +  $timer_overrides,
@@ -95,19 +94,19 @@ define systemd::timer_wrapper (
     },
   }
 
-  service { "${unit_name}.timer":
+  service { "${title}.timer":
     ensure => $service_ensure,
     enable => $service_ensure,
   }
 
   if $ensure == 'present' {
-    Systemd::Manage_unit["${unit_name}.service"]
-    -> Systemd::Manage_unit["${unit_name}.timer"]
-    -> Service["${unit_name}.timer"]
+    Systemd::Manage_unit["${title}.service"]
+    -> Systemd::Manage_unit["${title}.timer"]
+    -> Service["${title}.timer"]
   } else {
     # Ensure the timer is stopped and disabled before the service
-    Service["${unit_name}.timer"]
-    -> Systemd::Manage_unit["${unit_name}.timer"]
-    -> Systemd::Manage_unit["${unit_name}.service"]
+    Service["${title}.timer"]
+    -> Systemd::Manage_unit["${title}.timer"]
+    -> Systemd::Manage_unit["${title}.service"]
   }
 }

--- a/spec/defines/timer_wrapper_spec.rb
+++ b/spec/defines/timer_wrapper_spec.rb
@@ -73,18 +73,7 @@ describe 'systemd::timer_wrapper' do
           end
 
           it {
-            is_expected.to compile
-            is_expected.to contain_file('/etc/systemd/system/t-i-t-l-e.timer')
-            is_expected.to contain_systemd__manage_unit('t-i-t-l-e.timer')
-            is_expected.to contain_systemd__unit_file('t-i-t-l-e.timer')
-            is_expected.to contain_file('/etc/systemd/system/t-i-t-l-e.service')
-            is_expected.to contain_systemd__manage_unit('t-i-t-l-e.service')
-            is_expected.to contain_systemd__unit_file('t-i-t-l-e.service')
-            is_expected.to contain_service('t-i-t-l-e.timer')
-            is_expected.to contain_exec('systemd-t-i-t-l-e.service-systemctl-daemon-reload')
-            is_expected.to contain_exec('systemd-t-i-t-l-e.timer-systemctl-daemon-reload')
-            is_expected.to contain_Systemd__Daemon_reload('t-i-t-l-e.service')
-            is_expected.to contain_Systemd__Daemon_reload('t-i-t-l-e.timer')
+            is_expected.to compile.and_raise_error(%r{expects a match for Systemd::Unit = Pattern})
           }
         end
 


### PR DESCRIPTION
#### Pull Request (PR) description
Don't treat unit names with `systemd::escape`. If you have `systemd::timer_wrapper` instances with names that contain special characters like slashes and umlauts this will result in a validation error.  In such cases you can produce the previous  behaviour by using `systemd::escape yourself` for example:

```puppet
systemd::timer_wrapper {systemd::escape( 'my_timer'):
  ensure        => 'present',
  command       => '/usr/bin/echo "Hello World"',
  on_calendar   => '*:0/5',
}
```

It is possible that this change will create duplicate resources in case the resource name was escaped but the unescaped name is also valid. In those cases make sure to remove the duplicate, e.g. like so:
```puppet
systemd::timer_wrapper { systemd::escape("someTitle"):
  ensure => absent,
}
```
#### This Pull Request (PR) fixes the following issues

Fixes #451 

