### PR TITLE
fix typo in service_limits deprecation message

### DIFF
--- a/manifests/service_limits.pp
+++ b/manifests/service_limits.pp
@@ -74,7 +74,7 @@ define systemd::service_limits (
       }
     }.reduce | $_memo, $_value | { $_memo + $_value }
 
-    deprecation("systemd::servicelimits - ${title}",'systemd::servicelimits is deprecated, use systemd::manage_dropin')
+    deprecation("systemd::service_limits - ${title}",'systemd::service_limits is deprecated, use systemd::manage_dropin')
     systemd::manage_dropin { "${name}-90-limits.conf":
       ensure                  => $ensure,
       unit                    => $name,
@@ -85,7 +85,7 @@ define systemd::service_limits (
       notify_service          => true,
     }
   } else {
-    deprecation("systemd::servicelimits ${title}",'systemd::servicelimits is deprecated, use systemd::dropin_file or systemd::manage_dropin')
+    deprecation("systemd::service_limits ${title}",'systemd::service_limits is deprecated, use systemd::dropin_file or systemd::manage_dropin')
     systemd::dropin_file { "${name}-90-limits.conf":
       ensure                  => $ensure,
       unit                    => $name,


### PR DESCRIPTION
<!--
Thank you for contributing to this project!

- This project has a Contributor Code of Conduct: https://voxpupuli.org/coc/
- Please check that here is no existing issue or PR that addresses your problem.
- Our vulnerabilities reporting process is at https://voxpupuli.org/security/

-->
#### Pull Request (PR) description
Fix typo in `systemd::service_limits` deprecation message
