### PR TITLE
Allow setting a specific package name for systemd-oomd

### DIFF
--- a/REFERENCE.md
+++ b/REFERENCE.md
@@ -150,6 +150,7 @@ The following parameters are available in the `systemd` class:
 * [`coredump_settings`](#-systemd--coredump_settings)
 * [`coredump_backtrace`](#-systemd--coredump_backtrace)
 * [`manage_oomd`](#-systemd--manage_oomd)
+* [`oomd_package`](#-systemd--oomd_package)
 * [`oomd_ensure`](#-systemd--oomd_ensure)
 * [`oomd_settings`](#-systemd--oomd_settings)
 * [`udev_purge_rules`](#-systemd--udev_purge_rules)
@@ -652,6 +653,14 @@ Data type: `Boolean`
 Should systemd-oomd configuration be managed
 
 Default value: `false`
+
+##### <a name="-systemd--oomd_package"></a>`oomd_package`
+
+Data type: `Optional[String[1]]`
+
+Name of the package required for systemd-oomd, if any
+
+Default value: `undef`
 
 ##### <a name="-systemd--oomd_ensure"></a>`oomd_ensure`
 

--- a/data/RedHat-family-9.yaml
+++ b/data/RedHat-family-9.yaml
@@ -1,5 +1,6 @@
 ---
 systemd::resolved_package: 'systemd-resolved'
+systemd::oomd_package: 'systemd-oomd'
 
 systemd::accounting:
   DefaultCPUAccounting: 'yes'

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -205,6 +205,9 @@
 # @param manage_oomd
 #   Should systemd-oomd configuration be managed
 #
+# @param oomd_package
+#   Name of the package required for systemd-oomd, if any
+#
 # @param oomd_ensure
 #   The state that the ``oomd`` service should be in
 #
@@ -273,6 +276,7 @@ class systemd (
   Systemd::CoredumpSettings                           $coredump_settings = {},
   Boolean                                             $coredump_backtrace = false,
   Boolean                                             $manage_oomd = false,
+  Optional[String[1]]                                 $oomd_package = undef,
   Enum['stopped','running']                           $oomd_ensure = 'running',
   Systemd::OomdSettings                               $oomd_settings = {},
   Boolean                                             $udev_purge_rules = false,

--- a/manifests/install.pp
+++ b/manifests/install.pp
@@ -8,6 +8,12 @@ class systemd::install {
     }
   }
 
+  if $systemd::manage_oomd and $systemd::oomd_package {
+    package { $systemd::oomd_package:
+      ensure => present,
+    }
+  }
+
   if $systemd::manage_resolved and $systemd::resolved_package {
     package { $systemd::resolved_package:
       ensure => present,


### PR DESCRIPTION
<!--
Thank you for contributing to this project!

- This project has a Contributor Code of Conduct: https://voxpupuli.org/coc/
- Please check that here is no existing issue or PR that addresses your problem.
- Our vulnerabilities reporting process is at https://voxpupuli.org/security/

-->
#### Pull Request (PR) description
This allows folks to set a specific name for systemd-oomd if it is a separate package from systemd (RHEL9 is this way).

The existing `install.pp` doesn't seem to have tests so...

#### This Pull Request (PR) fixes the following issues
<!--
Replace this comment with the list of issues or n/a.
Use format:
Fixes #123
Fixes #124
-->
