### PR TITLE
RFC: add Kube unit support

### DIFF
--- a/REFERENCE.md
+++ b/REFERENCE.md
@@ -67,6 +67,7 @@
 * [`Systemd::Unit::Amount`](#Systemd--Unit--Amount): Systemd definition of amount, often bytes or united bytes
 * [`Systemd::Unit::AmountOrPercent`](#Systemd--Unit--AmountOrPercent): Systemd definition of amount, often bytes or united bytes
 * [`Systemd::Unit::Install`](#Systemd--Unit--Install): Possible keys for the [Install] section of a unit file
+* [`Systemd::Unit::Kube`](#Systemd--Unit--Kube): Possible keys for the [Kube] section of a unit file
 * [`Systemd::Unit::Path`](#Systemd--Unit--Path): Possible keys for the [Path] section of a unit file
 * [`Systemd::Unit::Percent`](#Systemd--Unit--Percent): Systemd definition of a percentage
 * [`Systemd::Unit::Service`](#Systemd--Unit--Service): Possible keys for the [Service] section of a unit file
@@ -1022,6 +1023,7 @@ The following parameters are available in the `systemd::manage_dropin` defined t
 * [`timer_entry`](#-systemd--manage_dropin--timer_entry)
 * [`path_entry`](#-systemd--manage_dropin--path_entry)
 * [`socket_entry`](#-systemd--manage_dropin--socket_entry)
+* [`kube_entry`](#-systemd--manage_dropin--kube_entry)
 
 ##### <a name="-systemd--manage_dropin--unit"></a>`unit`
 
@@ -1162,6 +1164,14 @@ Default value: `undef`
 Data type: `Optional[Systemd::Unit::Socket]`
 
 key value pairs for the [Socket] section of the unit file
+
+Default value: `undef`
+
+##### <a name="-systemd--manage_dropin--kube_entry"></a>`kube_entry`
+
+Data type: `Optional[Systemd::Unit::Kube]`
+
+key value pairs for the [Kube] section of the unit file
 
 Default value: `undef`
 
@@ -2183,7 +2193,7 @@ The following parameters are available in the `systemd::unit_file` defined type:
 
 ##### <a name="-systemd--unit_file--name"></a>`name`
 
-Data type: `Pattern['^[^/]+\.(service|socket|device|mount|automount|swap|target|path|timer|slice|scope)$']`
+Data type: `Pattern['^[^/]+\.(service|socket|device|mount|automount|swap|target|path|timer|slice|scope|kube)$']`
 
 The target unit file to create
 
@@ -2746,7 +2756,7 @@ custom datatype that validates different filenames for systemd units and unit te
 * **See also**
   * https://www.freedesktop.org/software/systemd/man/systemd.unit.html
 
-Alias of `Pattern[/^[a-zA-Z0-9:\-_.\\@%]+\.(service|socket|device|mount|automount|swap|target|path|timer|slice|scope)$/]`
+Alias of `Pattern[/^[a-zA-Z0-9:\-_.\\@%]+\.(service|socket|device|mount|automount|swap|target|path|timer|slice|scope|kube)$/]`
 
 ### <a name="Systemd--Unit--Amount"></a>`Systemd::Unit::Amount`
 
@@ -2786,6 +2796,33 @@ Struct[{
     Optional['WantedBy']   => Variant[Enum[''],Systemd::Unit,Array[Variant[Enum[''],Systemd::Unit],1]],
     Optional['RequiredBy'] => Variant[Enum[''],Systemd::Unit,Array[Variant[Enum[''],Systemd::Unit],1]],
     Optional['Also']       => Variant[Enum[''],Systemd::Unit,Array[Variant[Enum[''],Systemd::Unit],1]],
+  }]
+```
+
+### <a name="Systemd--Unit--Kube"></a>`Systemd::Unit::Kube`
+
+Possible keys for the [Kube] section of a unit file
+
+* **See also**
+  * https://docs.podman.io/en/latest/markdown/podman-systemd.unit.5.html#kube-units-kube
+
+Alias of
+
+```puppet
+Struct[{
+    Optional['AutoUpdate'] => String,
+    Optional['ConfigMap']  => Stdlib::Unixpath,
+    Optional['ContainersConfModule'] => Stdlib::Unixpath,
+    Optional['ExitCodePropagation'] => Enum['all', 'any', 'none'],
+    Optioanl['GlobalArgs'] => String,
+    Optional['KubeDownForce'] => Boolean,
+    Optional['LogDriver'] => String,
+    Optional['Network'] => String,
+    Optional['PodmanArgs'] => String,
+    Optional['PublishPort'] => Variant[String, Integer],
+    Optional['SetWorkingDirectory'] => Enum['yaml', 'unit'],
+    Optional['UserNS'] => String,
+    Optional['Yaml'] => Stdlib::Unixpath,
   }]
 ```
 

--- a/manifests/manage_dropin.pp
+++ b/manifests/manage_dropin.pp
@@ -88,6 +88,7 @@
 # @param timer_entry key value pairs for [Timer] section of the unit file
 # @param path_entry key value pairs for [Path] section of the unit file
 # @param socket_entry key value pairs for the [Socket] section of the unit file
+# @param kube_entry key value pairs for the [Kube] section of the unit file
 #
 define systemd::manage_dropin (
   Systemd::Unit                    $unit,
@@ -108,6 +109,7 @@ define systemd::manage_dropin (
   Optional[Systemd::Unit::Timer]   $timer_entry             = undef,
   Optional[Systemd::Unit::Path]    $path_entry              = undef,
   Optional[Systemd::Unit::Socket]  $socket_entry            = undef,
+  Optional[Systemd::Unit::Kube]    $kube_entry              = undef,
 ) {
   if $timer_entry and $unit !~ Pattern['^[^/]+\.timer'] {
     fail("Systemd::Manage_dropin[${name}]: for unit ${unit} timer_entry is only valid for timer units")
@@ -123,6 +125,10 @@ define systemd::manage_dropin (
 
   if $slice_entry and $unit !~ Pattern['^[^/]+\.slice'] {
     fail("Systemd::Manage_dropin[${name}]: for unit ${unit} slice_entry is only valid for slice units")
+  }
+
+  if $kube_entry and $unit !~ Pattern['^[^/]+\.kube'] {
+    fail("Systemd::Manage_dropin[${name}]: for unit ${unit} slice_entry is only valid for kube units")
   }
 
   systemd::dropin_file { $name:
@@ -145,6 +151,7 @@ define systemd::manage_dropin (
         'timer_entry'   => $timer_entry,
         'path_entry'    => $path_entry,
         'socket_entry'  => $socket_entry,
+        'kube_entry'    => $kube_entry,
     }),
   }
 }

--- a/manifests/unit_file.pp
+++ b/manifests/unit_file.pp
@@ -4,7 +4,7 @@
 #
 # @see systemd.unit(5)
 #
-# @param name [Pattern['^[^/]+\.(service|socket|device|mount|automount|swap|target|path|timer|slice|scope)$']]
+# @param name [Pattern['^[^/]+\.(service|socket|device|mount|automount|swap|target|path|timer|slice|scope|kube)$']]
 #   The target unit file to create
 #
 # @param ensure

--- a/templates/unit_file.epp
+++ b/templates/unit_file.epp
@@ -6,6 +6,7 @@
  Optional[Hash] $timer_entry,
  Optional[Hash] $path_entry,
  Optional[Hash] $socket_entry,
+ Optional[Hash] $kube_entry,
 | -%>
 <%-
 
@@ -14,6 +15,7 @@
 
  $_unit_sections = [
    'Unit',
+   'Kube',
    'Slice',
    'Service',
    'Timer',

--- a/types/unit.pp
+++ b/types/unit.pp
@@ -1,3 +1,3 @@
 # @summary custom datatype that validates different filenames for systemd units and unit templates
 # @see https://www.freedesktop.org/software/systemd/man/systemd.unit.html
-type Systemd::Unit = Pattern[/^[a-zA-Z0-9:\-_.\\@%]+\.(service|socket|device|mount|automount|swap|target|path|timer|slice|scope)$/]
+type Systemd::Unit = Pattern[/^[a-zA-Z0-9:\-_.\\@%]+\.(service|socket|device|mount|automount|swap|target|path|timer|slice|scope|kube)$/]

--- a/types/unit/kube.pp
+++ b/types/unit/kube.pp
@@ -1,0 +1,19 @@
+# @summary Possible keys for the [Kube] section of a unit file
+# @see https://docs.podman.io/en/latest/markdown/podman-systemd.unit.5.html#kube-units-kube
+type Systemd::Unit::Kube = Struct[
+  {
+    Optional['AutoUpdate'] => String,
+    Optional['ConfigMap']  => Stdlib::Unixpath,
+    Optional['ContainersConfModule'] => Stdlib::Unixpath,
+    Optional['ExitCodePropagation'] => Enum['all', 'any', 'none'],
+    Optioanl['GlobalArgs'] => String,
+    Optional['KubeDownForce'] => Boolean,
+    Optional['LogDriver'] => String,
+    Optional['Network'] => String,
+    Optional['PodmanArgs'] => String,
+    Optional['PublishPort'] => Variant[String, Integer],
+    Optional['SetWorkingDirectory'] => Enum['yaml', 'unit'],
+    Optional['UserNS'] => String,
+    Optional['Yaml'] => Stdlib::Unixpath,
+  }
+]


### PR DESCRIPTION
#### Pull Request (PR) description
Podman integration brings support for multiple Unit types, including Kube unit that allows to start a pod with a YAML file declaration.

This PR in its current form is an RFC to discuss if these Unit Types are in the scope of this module. Or if they should be added to another module.