### PR TITLE
Add support for podman quadlets

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,6 +20,21 @@ This module declares exec resources to create global sync points for reloading s
 
 There are two ways to use this module.
 
+### podman quadlet files
+
+Let this module handle file creation and reloading of systemd.
+
+```puppet
+systemd::quadlet_file { 'foo.kube':
+  content         => file("${module_name}/foo.kube"),
+  enable          => true,
+  active          => true,
+  service_restart => true,
+}
+```
+
+All file types supported by podman quadlet are possible, see [the quadlet documentation](https://docs.podman.io/en/latest/markdown/podman-systemd.unit.5.html) for all supported types.
+
 ### unit files
 
 Let this module handle file creation.

--- a/REFERENCE.md
+++ b/REFERENCE.md
@@ -35,6 +35,7 @@
 * [`systemd::manage_unit`](#systemd--manage_unit): Generate unit file from template
 * [`systemd::modules_load`](#systemd--modules_load): Creates a modules-load.d drop file
 * [`systemd::network`](#systemd--network): Creates network config for systemd-networkd
+* [`systemd::quadlet_file`](#systemd--quadlet_file): Creates a systemd Podman Quadlet file
 * [`systemd::service_limits`](#systemd--service_limits): Deprecated - Adds a set of custom limits to the service
 * [`systemd::timer`](#systemd--timer): Create a timer and optionally a service unit to execute with the timer unit
 * [`systemd::timer_wrapper`](#systemd--timer_wrapper): Helper to define timer and accompanying services for a given task (cron like interface).
@@ -62,6 +63,7 @@
 * [`Systemd::LogindSettings::Ensure`](#Systemd--LogindSettings--Ensure): defines allowed ensure states for systemd-logind settings
 * [`Systemd::MachineInfoSettings`](#Systemd--MachineInfoSettings): Matches Systemd machine-info (hostnamectl) file Struct
 * [`Systemd::OomdSettings`](#Systemd--OomdSettings): Configurations for oomd.conf
+* [`Systemd::Quadlet`](#Systemd--Quadlet): custom datatype that validates different filenames for quadlet units
 * [`Systemd::ServiceLimits`](#Systemd--ServiceLimits): Deprecated - Matches Systemd Service Limit Struct
 * [`Systemd::Unit`](#Systemd--Unit): custom datatype that validates different filenames for systemd units and unit templates
 * [`Systemd::Unit::Amount`](#Systemd--Unit--Amount): Systemd definition of amount, often bytes or united bytes
@@ -1620,6 +1622,149 @@ whether systemd-networkd should be restarted on changes, defaults to true. `$sys
 
 Default value: `true`
 
+### <a name="systemd--quadlet_file"></a>`systemd::quadlet_file`
+
+Quadlet will generate a unit file, and this service can be managed by puppet.
+
+* **See also**
+  * podman.systemd.unit(5)
+
+#### Parameters
+
+The following parameters are available in the `systemd::quadlet_file` defined type:
+
+* [`name`](#-systemd--quadlet_file--name)
+* [`ensure`](#-systemd--quadlet_file--ensure)
+* [`content`](#-systemd--quadlet_file--content)
+* [`path`](#-systemd--quadlet_file--path)
+* [`source`](#-systemd--quadlet_file--source)
+* [`owner`](#-systemd--quadlet_file--owner)
+* [`group`](#-systemd--quadlet_file--group)
+* [`mode`](#-systemd--quadlet_file--mode)
+* [`enable`](#-systemd--quadlet_file--enable)
+* [`active`](#-systemd--quadlet_file--active)
+* [`restart`](#-systemd--quadlet_file--restart)
+* [`service_parameters`](#-systemd--quadlet_file--service_parameters)
+* [`daemon_reload`](#-systemd--quadlet_file--daemon_reload)
+* [`service_restart`](#-systemd--quadlet_file--service_restart)
+
+##### <a name="-systemd--quadlet_file--name"></a>`name`
+
+The name of the quadlet file
+
+##### <a name="-systemd--quadlet_file--ensure"></a>`ensure`
+
+Data type: `Enum['present', 'absent']`
+
+The state of the quadlet file to ensure
+
+Default value: `'present'`
+
+##### <a name="-systemd--quadlet_file--content"></a>`content`
+
+Data type: `Optional[Variant[String, Sensitive[String], Deferred]]`
+
+The full content of the quadlet file
+
+Default value: `undef`
+
+##### <a name="-systemd--quadlet_file--path"></a>`path`
+
+Data type: `Stdlib::Absolutepath`
+
+The path where the quadlet file will be created
+For systemd in user mode use any of
+- ~/.config/containers/systemd
+- /etc/containers/systemd/users/$(UID)
+
+For global systemd use any of:
+- /etc/containers/systemd
+- /usr/share/containers/systemd
+
+Default value: `'/etc/containers/systemd'`
+
+##### <a name="-systemd--quadlet_file--source"></a>`source`
+
+Data type: `Optional[String]`
+
+The ``File`` resource compatible ``source``
+
+* Mutually exclusive with ``$content``
+
+Default value: `undef`
+
+##### <a name="-systemd--quadlet_file--owner"></a>`owner`
+
+Data type: `String[1]`
+
+The owner to set on the unit file
+
+Default value: `'root'`
+
+##### <a name="-systemd--quadlet_file--group"></a>`group`
+
+Data type: `String[1]`
+
+The group to set on the unit file
+
+Default value: `'root'`
+
+##### <a name="-systemd--quadlet_file--mode"></a>`mode`
+
+Data type: `String[1]`
+
+The mode to set on the unit file
+
+Default value: `'0444'`
+
+##### <a name="-systemd--quadlet_file--enable"></a>`enable`
+
+Data type: `Optional[Boolean]`
+
+If set, will manage the unit enablement status.
+
+Default value: `undef`
+
+##### <a name="-systemd--quadlet_file--active"></a>`active`
+
+Data type: `Optional[Boolean]`
+
+If set, will manage the state of the unit.
+
+Default value: `undef`
+
+##### <a name="-systemd--quadlet_file--restart"></a>`restart`
+
+Data type: `Optional[String]`
+
+Specify a restart command manually. If left unspecified, a standard Puppet service restart happens.
+
+Default value: `undef`
+
+##### <a name="-systemd--quadlet_file--service_parameters"></a>`service_parameters`
+
+Data type: `Hash[String[1], Any]`
+
+hash that will be passed with the splat operator to the service resource
+
+Default value: `{}`
+
+##### <a name="-systemd--quadlet_file--daemon_reload"></a>`daemon_reload`
+
+Data type: `Boolean`
+
+call `systemd::daemon-reload` to ensure that the modified unit file is loaded
+
+Default value: `true`
+
+##### <a name="-systemd--quadlet_file--service_restart"></a>`service_restart`
+
+Data type: `Boolean`
+
+restart (notify) the service when unit file changed
+
+Default value: `true`
+
 ### <a name="systemd--service_limits"></a>`systemd::service_limits`
 
 Deprecated - Adds a set of custom limits to the service
@@ -2685,6 +2830,16 @@ Struct[{
     Optional['DefaultMemoryPressureDurationSec'] => Integer[0],
   }]
 ```
+
+### <a name="Systemd--Quadlet"></a>`Systemd::Quadlet`
+
+custom datatype that validates different filenames for quadlet units
+
+* **See also**
+  * https://docs.podman.io/en/latest/markdown/podman-systemd.unit.5.html
+  * https://www.freedesktop.org/software/systemd/man/systemd.unit.html
+
+Alias of `Pattern[/^[a-zA-Z0-9:\-_.\\@%]+\.(container|volume|network|kube|image|build|pod)$/]`
 
 ### <a name="Systemd--ServiceLimits"></a>`Systemd::ServiceLimits`
 

--- a/manifests/quadlet_file.pp
+++ b/manifests/quadlet_file.pp
@@ -1,0 +1,113 @@
+# @summary Creates a systemd Podman Quadlet file
+# Quadlet will generate a unit file, and this service can be managed by puppet.
+# @api public
+#
+# @see podman.systemd.unit(5)
+#
+# @param name
+#   The name of the quadlet file
+#
+# @param ensure
+#   The state of the quadlet file to ensure
+#
+# @param content
+#   The full content of the quadlet file
+#
+# @param path
+#   The path where the quadlet file will be created
+#   For systemd in user mode use any of
+#   - ~/.config/containers/systemd
+#   - /etc/containers/systemd/users/$(UID)
+#
+#   For global systemd use any of:
+#   - /etc/containers/systemd
+#   - /usr/share/containers/systemd
+#
+# @param source
+#   The ``File`` resource compatible ``source``
+#
+#   * Mutually exclusive with ``$content``
+#
+# @param owner
+#   The owner to set on the unit file
+#
+# @param group
+#   The group to set on the unit file
+#
+# @param mode
+#   The mode to set on the unit file
+#
+# @param enable
+#   If set, will manage the unit enablement status.
+#
+# @param active
+#   If set, will manage the state of the unit.
+#
+# @param restart
+#   Specify a restart command manually. If left unspecified, a standard Puppet service restart happens.
+#
+# @param service_parameters
+#   hash that will be passed with the splat operator to the service resource
+#
+# @param daemon_reload
+#   call `systemd::daemon-reload` to ensure that the modified unit file is loaded
+#
+# @param service_restart
+#   restart (notify) the service when unit file changed
+define systemd::quadlet_file (
+  Enum['present', 'absent']                $ensure    = 'present',
+  Stdlib::Absolutepath                     $path      = '/etc/containers/systemd',
+  Optional[Variant[String, Sensitive[String], Deferred]] $content = undef,
+  Optional[String]                         $source    = undef,
+  String[1]                                $owner     = 'root',
+  String[1]                                $group     = 'root',
+  String[1]                                $mode      = '0444',
+  Optional[Boolean]                        $enable    = undef,
+  Optional[Boolean]                        $active    = undef,
+  Optional[String]                         $restart   = undef,
+  Hash[String[1], Any]                     $service_parameters = {},
+  Boolean                                  $daemon_reload = true,
+  Boolean                                  $service_restart = true,
+) {
+  include systemd
+  assert_type(Systemd::Quadlet, $name)
+  $service_name=regsubst($name, '^(.*)\\..*', '\\1.service')
+
+  file { "${path}/${name}":
+    ensure  => $ensure,
+    content => $content,
+    source  => $source,
+    owner   => $owner,
+    group   => $group,
+    mode    => $mode,
+  }
+
+  if $daemon_reload {
+    ensure_resource('systemd::daemon_reload', $name)
+
+    File["${path}/${name}"] ~> Systemd::Daemon_reload[$name]
+  }
+
+  if $enable != undef or $active != undef {
+    service { $service_name:
+      ensure   => $active,
+      enable   => $enable,
+      restart  => $restart,
+      provider => 'systemd',
+      *        => $service_parameters,
+    }
+
+    if $ensure == 'absent' {
+      if $enable or $active {
+        fail("Can't ensure the unit file is absent and activate/enable the service at the same time")
+      }
+      Service[$service_name] -> File["${path}/${name}"]
+    } elsif $service_restart {
+      File["${path}/${name}"] ~> Service[$service_name]
+
+      if $daemon_reload {
+        Systemd::Daemon_reload[$name] ~> Service[$service_name]
+      }
+    }
+  }
+}

--- a/types/quadlet.pp
+++ b/types/quadlet.pp
@@ -1,0 +1,3 @@
+# @summary custom datatype that validates different filenames for quadlet units
+# @see https://docs.podman.io/en/latest/markdown/podman-systemd.unit.5.html https://www.freedesktop.org/software/systemd/man/systemd.unit.html
+type Systemd::Quadlet = Pattern[/^[a-zA-Z0-9:\-_.\\@%]+\.(container|volume|network|kube|image|build|pod)$/]


### PR DESCRIPTION
#### Pull Request (PR) description
This PR adds support for podman Quadlets, a generator for systemd that creates units automatically for files in a specific folder.

Tested with a kube Yaml file and it starts the pod.