### PR TITLE
README.md: correct service limits example

### DIFF
--- a/README.md
+++ b/README.md
@@ -297,9 +297,9 @@ To migrate from the above example, use the following:
 
 ```puppet
 systemd::manage_dropin { 'foo.service-90-limits.conf':
-  unit     => 'foo.service',
-  filename => '90-limits.conf',
-  limits   => {
+  unit            => 'foo.service',
+  filename        => '90-limits.conf',
+  service_entry   => {
     'LimitNOFILE' => 8192,
     'LimitNPROC'  => 16384,
   },


### PR DESCRIPTION
`limits` should be `service_entry` as noted in
https://github.com/voxpupuli/puppet-systemd/pull/461/files#r1668626577.
