### PR TITLE
Replace deprecated `shell_escape` function with `stdlib::shell_escape`

### DIFF
--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -284,7 +284,7 @@ class systemd (
   contain systemd::install
 
   if $default_target {
-    $target = shell_escape($default_target)
+    $target = stdlib::shell_escape($default_target)
     service { $target:
       ensure => 'running',
       enable => true,

--- a/metadata.json
+++ b/metadata.json
@@ -10,7 +10,7 @@
   "dependencies": [
     {
       "name": "puppetlabs/stdlib",
-      "version_requirement": ">= 8.5.0 < 10.0.0"
+      "version_requirement": ">= 9.0.0 < 10.0.0"
     },
     {
       "name": "puppetlabs/inifile",


### PR DESCRIPTION
<!--
Thank you for contributing to this project!

- This project has a Contributor Code of Conduct: https://voxpupuli.org/coc/
- Please check that here is no existing issue or PR that addresses your problem.
- Our vulnerabilities reporting process is at https://voxpupuli.org/security/

-->
#### Pull Request (PR) description

For stdlib 9.x and later, the shell_escape function has been moved to stdlib::shell_escape.

This change breaks compatiblity with stdlib 8.x

#### This Pull Request (PR) fixes the following issues

Fixes #479 
