### PR TITLE
Reload udev rules after change

### DIFF
--- a/REFERENCE.md
+++ b/REFERENCE.md
@@ -134,6 +134,7 @@ The following parameters are available in the `systemd` class:
 * [`udev_resolve_names`](#-systemd--udev_resolve_names)
 * [`udev_timeout_signal`](#-systemd--udev_timeout_signal)
 * [`udev_rules`](#-systemd--udev_rules)
+* [`udev_reload`](#-systemd--udev_reload)
 * [`machine_info_settings`](#-systemd--machine_info_settings)
 * [`manage_logind`](#-systemd--manage_logind)
 * [`logind_settings`](#-systemd--logind_settings)
@@ -524,6 +525,14 @@ Config Hash that is used to generate instances of our
 `udev::rule` define.
 
 Default value: `{}`
+
+##### <a name="-systemd--udev_reload"></a>`udev_reload`
+
+Data type: `Boolean`
+
+Whether udev rules should be automatically reloaded upon change.
+
+Default value: `false`
 
 ##### <a name="-systemd--machine_info_settings"></a>`machine_info_settings`
 

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -157,6 +157,9 @@
 #   Config Hash that is used to generate instances of our
 #   `udev::rule` define.
 #
+# @param udev_reload
+#   Whether udev rules should be automatically reloaded upon change.
+#
 # @param machine_info_settings
 #   Settings to place into /etc/machine-info (hostnamectl)
 #
@@ -261,6 +264,7 @@ class systemd (
   Optional[Integer]                                   $udev_event_timeout = undef,
   Optional[Enum['early', 'late', 'never']]            $udev_resolve_names = undef,
   Optional[Variant[Integer,String]]                   $udev_timeout_signal = undef,
+  Boolean                                             $udev_reload = false,
   Boolean                                             $manage_logind = false,
   Systemd::LogindSettings                             $logind_settings = {},
   Boolean                                             $manage_all_network_files = false,

--- a/manifests/udev/rule.pp
+++ b/manifests/udev/rule.pp
@@ -43,7 +43,7 @@ define systemd::udev::rule (
     owner                   => 'root',
     group                   => 'root',
     mode                    => '0444',
-    notify                  => $notify_services,
+    notify                  => $notify_services << 'Exec[systemd-udev_reload]',
     selinux_ignore_defaults => $selinux_ignore_defaults,
     content                 => epp("${module_name}/udev_rule.epp", { 'rules' => $rules }),
   }

--- a/manifests/udev/rule.pp
+++ b/manifests/udev/rule.pp
@@ -38,12 +38,22 @@ define systemd::udev::rule (
     fail("systemd::udev::rule - ${name}: param rules is empty, you need to pass rules")
   }
 
+  if $systemd::udev_reload {
+    if $notify_services =~ Array {
+      $_notify = $notify_services << 'Exec[systemd-udev_reload]'
+    } else {
+      $_notify = [$notify_services, 'Exec[systemd-udev_reload]']
+    }
+  } else {
+    $_notify = $notify_services
+  }
+
   file { join([$path, $name], '/'):
     ensure                  => $ensure,
     owner                   => 'root',
     group                   => 'root',
     mode                    => '0444',
-    notify                  => $notify_services << 'Exec[systemd-udev_reload]',
+    notify                  => $_notify,
     selinux_ignore_defaults => $selinux_ignore_defaults,
     content                 => epp("${module_name}/udev_rule.epp", { 'rules' => $rules }),
   }

--- a/manifests/udev/rule.pp
+++ b/manifests/udev/rule.pp
@@ -38,14 +38,14 @@ define systemd::udev::rule (
     fail("systemd::udev::rule - ${name}: param rules is empty, you need to pass rules")
   }
 
-  if $systemd::udev_reload {
+  $_notify = if $systemd::udev_reload {
     if $notify_services =~ Array {
-      $_notify = $notify_services << 'Exec[systemd-udev_reload]'
+      $notify_services << 'Exec[systemd-udev_reload]'
     } else {
-      $_notify = [$notify_services, 'Exec[systemd-udev_reload]']
+      [$notify_services, 'Exec[systemd-udev_reload]']
     }
   } else {
-    $_notify = $notify_services
+    $notify_services
   }
 
   file { join([$path, $name], '/'):

--- a/manifests/udevd.pp
+++ b/manifests/udevd.pp
@@ -36,4 +36,11 @@ class systemd::udevd {
       * => $udev_rule,
     }
   }
+
+  exec { 'systemd-udev_reload':
+    command     => 'udevadm control --reload-rules && udevadm trigger',
+    refreshonly => true,
+    path        => $facts['path'],
+  }
+
 }

--- a/manifests/udevd.pp
+++ b/manifests/udevd.pp
@@ -42,5 +42,4 @@ class systemd::udevd {
     refreshonly => true,
     path        => $facts['path'],
   }
-
 }

--- a/spec/classes/init_spec.rb
+++ b/spec/classes/init_spec.rb
@@ -642,6 +642,7 @@ describe 'systemd' do
           let(:params) do
             {
               manage_udevd: true,
+              udev_reload: true,
               udev_log: 'daemon',
               udev_children_max: 1,
               udev_exec_delay: 2,
@@ -664,6 +665,7 @@ describe 'systemd' do
               {
                 manage_udevd: true,
                 udev_purge_rules: true,
+                udev_reload: true,
               }
             end
 
@@ -702,6 +704,7 @@ describe 'systemd' do
                    ])
           }
 
+          it { is_expected.to contain_exec('systemd-udev_reload') }
           it { is_expected.to contain_file('/etc/udev/rules.d/example_raw.rules').that_notifies('Exec[systemd-udev_reload]') }
         end
 

--- a/spec/classes/init_spec.rb
+++ b/spec/classes/init_spec.rb
@@ -701,6 +701,8 @@ describe 'systemd' do
                      'ACTION=="add", KERNEL=="sdb", RUN+="/bin/raw /dev/raw/raw2 %N"',
                    ])
           }
+
+          it { is_expected.to contain_file('/etc/udev/rules.d/example_raw.rules').that_notifies('Exec[systemd-udev_reload]') }
         end
 
         context 'with machine-info' do

--- a/spec/defines/udev_rules_spec.rb
+++ b/spec/defines/udev_rules_spec.rb
@@ -88,7 +88,24 @@ describe 'systemd::udev::rule' do
           it { is_expected.to contain_file("/etc/udev/rules.d/#{title}").with_ensure('absent').with_notify([]) }
         end
 
-        describe 'ensured absent with notify' do
+        describe 'ensured absent with automatic reload' do
+          let(:pre_condition) do
+            <<-PUPPET
+            class { 'systemd': manage_udevd => true, manage_journald => false, udev_reload => true }
+            PUPPET
+          end
+          let(:params) do
+            {
+              ensure: 'absent',
+            }
+          end
+
+          it { is_expected.to compile.with_all_deps }
+
+          it { is_expected.to contain_file("/etc/udev/rules.d/#{title}").with_ensure('absent').with_notify(['Exec[systemd-udev_reload]']) }
+        end
+
+        describe 'ensured absent with custom notify' do
           let(:params) { { ensure: 'absent', notify_services: 'Service[systemd-udevd]', } }
 
           it { is_expected.to compile.with_all_deps }


### PR DESCRIPTION
#### Pull Request (PR) description

Automatically reload udev rules after a change. 

To enable this feature use
```yaml
systemd::udev_reload: true
```

A rule with a `String` notification would be then appended with `Exec[systemd-udev_reload]`

```yaml
systemd::udev::rule:
  notify: "Service[systemd-udevd]"
```
e.g. 
```
notify => [ Service[systemd-udevd], Exec[systemd-udev_reload] ]
```
would be used.

#### This Pull Request (PR) fixes the following issues

Fixes #484

