### PR TITLE
README: fix path in example

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,7 +36,7 @@ systemd::unit_file { 'foo.service':
 This is equivalent to:
 
 ```puppet
-file { '/usr/lib/systemd/system/foo.service':
+file { '/etc/systemd/system/foo.service':
   ensure => file,
   owner  => 'root',
   group  => 'root',


### PR DESCRIPTION
`/etc/systemd/system` is the path used in the code: https://github.com/voxpupuli/puppet-systemd/blob/ff0c85e828b17ec485c834b89cd00fbc4fd90665/manifests/unit_file.pp#L73

Fixes #488.
