### PR TITLE
Support Mount units for manage_unit or dropin types

### DIFF
--- a/REFERENCE.md
+++ b/REFERENCE.md
@@ -67,6 +67,7 @@
 * [`Systemd::Unit::Amount`](#Systemd--Unit--Amount): Systemd definition of amount, often bytes or united bytes
 * [`Systemd::Unit::AmountOrPercent`](#Systemd--Unit--AmountOrPercent): Systemd definition of amount, often bytes or united bytes
 * [`Systemd::Unit::Install`](#Systemd--Unit--Install): Possible keys for the [Install] section of a unit file
+* [`Systemd::Unit::Mount`](#Systemd--Unit--Mount): Possible keys for the [Mount] section of a unit file
 * [`Systemd::Unit::Path`](#Systemd--Unit--Path): Possible keys for the [Path] section of a unit file
 * [`Systemd::Unit::Percent`](#Systemd--Unit--Percent): Systemd definition of a percentage
 * [`Systemd::Unit::Service`](#Systemd--Unit--Service): Possible keys for the [Service] section of a unit file
@@ -1031,6 +1032,7 @@ The following parameters are available in the `systemd::manage_dropin` defined t
 * [`timer_entry`](#-systemd--manage_dropin--timer_entry)
 * [`path_entry`](#-systemd--manage_dropin--path_entry)
 * [`socket_entry`](#-systemd--manage_dropin--socket_entry)
+* [`mount_entry`](#-systemd--manage_dropin--mount_entry)
 
 ##### <a name="-systemd--manage_dropin--unit"></a>`unit`
 
@@ -1174,6 +1176,14 @@ key value pairs for the [Socket] section of the unit file
 
 Default value: `undef`
 
+##### <a name="-systemd--manage_dropin--mount_entry"></a>`mount_entry`
+
+Data type: `Optional[Systemd::Unit::Mount]`
+
+key value pairs for the [Mount] section of the unit file
+
+Default value: `undef`
+
 ### <a name="systemd--manage_unit"></a>`systemd::manage_unit`
 
 Generate unit file from template
@@ -1251,6 +1261,30 @@ systemd::manage_unit{'arcd@.service':
 }
 ```
 
+##### Mount a Filesystem and Use for a Service
+
+```puppet
+systemd::manage_unit { 'var-lib-sss-db.mount':
+  ensure      => present,
+  unit_entry  => {
+    'Description' => 'Mount sss tmpfs db',
+  },
+  mount_entry => {
+    'What'    => 'tmpfs',
+    'Where'   => '/var/lib/sss/db',
+    'Type'    => 'tmpfs',
+    'Options' => 'size=300M,mode=0700,uid=sssd,gid=sssd,rootcontext=system_u:object_r:sssd_var_lib_t:s0',
+  },
+}
+systemd::manage_dropin { 'tmpfs-db.conf':
+  ensure     => present,
+  unit       => 'sssd.service',
+  unit_entry => {
+    'RequiresMountsFor' => '/var/lib/sss/db',
+  },
+}
+```
+
 ##### Remove a unit file
 
 ```puppet
@@ -1284,6 +1318,7 @@ The following parameters are available in the `systemd::manage_unit` defined typ
 * [`timer_entry`](#-systemd--manage_unit--timer_entry)
 * [`path_entry`](#-systemd--manage_unit--path_entry)
 * [`socket_entry`](#-systemd--manage_unit--socket_entry)
+* [`mount_entry`](#-systemd--manage_unit--mount_entry)
 
 ##### <a name="-systemd--manage_unit--name"></a>`name`
 
@@ -1448,6 +1483,14 @@ Default value: `undef`
 Data type: `Optional[Systemd::Unit::Socket]`
 
 kev value paors for [Socket] section of the unit file.
+
+Default value: `undef`
+
+##### <a name="-systemd--manage_unit--mount_entry"></a>`mount_entry`
+
+Data type: `Optional[Systemd::Unit::Mount]`
+
+kev value pairs for [Mount] section of the unit file.
 
 Default value: `undef`
 
@@ -2795,6 +2838,30 @@ Struct[{
     Optional['WantedBy']   => Variant[Enum[''],Systemd::Unit,Array[Variant[Enum[''],Systemd::Unit],1]],
     Optional['RequiredBy'] => Variant[Enum[''],Systemd::Unit,Array[Variant[Enum[''],Systemd::Unit],1]],
     Optional['Also']       => Variant[Enum[''],Systemd::Unit,Array[Variant[Enum[''],Systemd::Unit],1]],
+  }]
+```
+
+### <a name="Systemd--Unit--Mount"></a>`Systemd::Unit::Mount`
+
+Possible keys for the [Mount] section of a unit file
+
+* **See also**
+  * https://www.freedesktop.org/software/systemd/man/latest/systemd.mount.html
+
+Alias of
+
+```puppet
+Struct[{
+    Optional['What']          => String[1],
+    Optional['Where']         => Stdlib::Unixpath,
+    Optional['Type']          => String[1],
+    Optional['Options']       => String[1],
+    Optional['SloppyOptions'] => Boolean,
+    Optional['LazyUnmount']   => Boolean,
+    Optional['ReadWriteOnly'] => Boolean,
+    Optional['ForceUnmount']  => Boolean,
+    Optional['DirectoryMode'] => Stdlib::Filemode,
+    Optional['TimeoutSec']    => String[0],
   }]
 ```
 

--- a/manifests/manage_dropin.pp
+++ b/manifests/manage_dropin.pp
@@ -88,6 +88,7 @@
 # @param timer_entry key value pairs for [Timer] section of the unit file
 # @param path_entry key value pairs for [Path] section of the unit file
 # @param socket_entry key value pairs for the [Socket] section of the unit file
+# @param mount_entry key value pairs for the [Mount] section of the unit file
 #
 define systemd::manage_dropin (
   Systemd::Unit                    $unit,
@@ -108,6 +109,7 @@ define systemd::manage_dropin (
   Optional[Systemd::Unit::Timer]   $timer_entry             = undef,
   Optional[Systemd::Unit::Path]    $path_entry              = undef,
   Optional[Systemd::Unit::Socket]  $socket_entry            = undef,
+  Optional[Systemd::Unit::Mount]   $mount_entry             = undef,
 ) {
   if $timer_entry and $unit !~ Pattern['^[^/]+\.timer'] {
     fail("Systemd::Manage_dropin[${name}]: for unit ${unit} timer_entry is only valid for timer units")
@@ -123,6 +125,10 @@ define systemd::manage_dropin (
 
   if $slice_entry and $unit !~ Pattern['^[^/]+\.slice'] {
     fail("Systemd::Manage_dropin[${name}]: for unit ${unit} slice_entry is only valid for slice units")
+  }
+
+  if $mount_entry and $unit !~ Pattern['^[^/]+\.mount'] {
+    fail("Systemd::Manage_dropin[${name}]: for unit ${unit} mount_entry is only valid for mount units")
   }
 
   systemd::dropin_file { $name:
@@ -145,6 +151,7 @@ define systemd::manage_dropin (
         'timer_entry'   => $timer_entry,
         'path_entry'    => $path_entry,
         'socket_entry'  => $socket_entry,
+        'mount_entry'   => $mount_entry,
     }),
   }
 }

--- a/spec/defines/manage_dropin_spec.rb
+++ b/spec/defines/manage_dropin_spec.rb
@@ -153,6 +153,25 @@ describe 'systemd::manage_dropin' do
           }
         end
 
+        context 'on a mount' do
+          let(:params) do
+            {
+              unit: 'var-lib-sss-db.mount',
+              mount_entry: {
+                'SloppyOptions' => true,
+              }
+            }
+          end
+
+          it { is_expected.to compile.with_all_deps }
+
+          it {
+            is_expected.to contain_systemd__dropin_file('foobar.conf').
+              with_unit('var-lib-sss-db.mount').
+              with_content(%r{^SloppyOptions=true$})
+          }
+        end
+
         context 'on a slice' do
           let(:params) do
             {

--- a/spec/defines/manage_unit_spec.rb
+++ b/spec/defines/manage_unit_spec.rb
@@ -99,6 +99,34 @@ describe 'systemd::manage_unit' do
           end
         end
 
+        context 'on a mount' do
+          let(:title) { 'var-lib-sss-db.mount' }
+
+          let(:params) do
+            {
+              unit_entry: {
+                Description: 'Mount sssd dir',
+              },
+              mount_entry: {
+                'What' => 'tmpfs',
+                'Where' => '/var/lib/sss/db',
+                'Type' => 'tmpfs',
+                'Options' => 'size=300M',
+              },
+            }
+          end
+
+          it { is_expected.to compile.with_all_deps }
+
+          it {
+            is_expected.to contain_systemd__unit_file('var-lib-sss-db.mount').
+              with_content(%r{^\[Mount\]$}).
+              with_content(%r{^What=tmpfs$}).
+              with_content(%r{^Where=/var/lib/sss/db$}).
+              with_content(%r{^Options=size=300M$})
+          }
+        end
+
         context 'on a timer' do
           let(:title) { 'winter.timer' }
 

--- a/spec/type_aliases/systemd_unit_mount_spec.rb
+++ b/spec/type_aliases/systemd_unit_mount_spec.rb
@@ -1,0 +1,42 @@
+# frozen_string_literal: true
+
+require 'spec_helper'
+
+describe 'Systemd::Unit::Mount' do
+  context 'with a key of What can have thing to mount' do
+    it { is_expected.to allow_value({ 'What' => 'tmpfs' }) }
+    it { is_expected.to allow_value({ 'What' => 'nfs://example.org/exports/home' }) }
+    it { is_expected.to allow_value({ 'What' => '/dev/vda1' }) }
+  end
+
+  context 'with a key of Where can have a path to mount on' do
+    it { is_expected.to allow_value({ 'Where' => '/mnt/foo' }) }
+    it { is_expected.to allow_value({ 'Where' => '/mnt/foo/file.txt' }) }
+  end
+
+  context 'with a key of Type can have a path to mount on' do
+    it { is_expected.to allow_value({ 'Type' => 'tmpfs' }) }
+    it { is_expected.to allow_value({ 'Type' => 'ext2' }) }
+  end
+
+  context 'with a key of Options can have a path to mount on' do
+    it { is_expected.to allow_value({ 'Options' => 'size=300M,mode=0700,uid=sssd,gid=sssd,root' }) }
+  end
+
+  context 'with a key of DirectoryMode can have a mode of' do
+    it { is_expected.to allow_value({ 'DirectoryMode' => '0700' }) }
+  end
+
+  context 'with a key of TimeoutSec can have a mode of' do
+    it { is_expected.to allow_value({ 'TimeoutSec' => '100' }) }
+    it { is_expected.to allow_value({ 'TimeoutSec' => '5min 20s' }) }
+    it { is_expected.to allow_value({ 'TimeoutSec' => '' }) }
+  end
+
+  %w[SloppyOptions LazyUnmount ReadWriteOnly ForceUnmount].each do |assert|
+    context "with a key of #{assert} can have values of a path" do
+      it { is_expected.to allow_value({ assert => false }) }
+      it { is_expected.to allow_value({ assert => true }) }
+    end
+  end
+end

--- a/templates/unit_file.epp
+++ b/templates/unit_file.epp
@@ -6,6 +6,7 @@
  Optional[Hash] $timer_entry,
  Optional[Hash] $path_entry,
  Optional[Hash] $socket_entry,
+ Optional[Hash] $mount_entry,
 | -%>
 <%-
 
@@ -20,6 +21,7 @@
    'Path',
    'Socket',
    'Install',
+   'Mount',
 ]
 
 # Directives which are pair of items to be expressed as a space seperated pair.

--- a/types/unit/mount.pp
+++ b/types/unit/mount.pp
@@ -1,0 +1,17 @@
+# @summary Possible keys for the [Mount] section of a unit file
+# @see https://www.freedesktop.org/software/systemd/man/latest/systemd.mount.html
+#
+type Systemd::Unit::Mount = Struct[
+  {
+    Optional['What']          => String[1],
+    Optional['Where']         => Stdlib::Unixpath,
+    Optional['Type']          => String[1],
+    Optional['Options']       => String[1],
+    Optional['SloppyOptions'] => Boolean,
+    Optional['LazyUnmount']   => Boolean,
+    Optional['ReadWriteOnly'] => Boolean,
+    Optional['ForceUnmount']  => Boolean,
+    Optional['DirectoryMode'] => Stdlib::Filemode,
+    Optional['TimeoutSec']    => String[0],
+  }
+]


### PR DESCRIPTION
#### Pull Request (PR) description

Support addition `.mount` units in `systemd::manage_unit` and `systemd::manage_dropin`.

e.g.

```puppet
systemd::manage_unit { 'var-lib-sss-db.mount':
  ensure      => $_use_ramdisk,
  unit_entry  => {
    'Description' => 'Mount a ram disk for sssd to use',
  },
  mount_entry => {
    'What'    => 'tmpfs',
    'Where'   => '/var/lib/sss/db',
    'Type'    => 'tmpfs',
    'Options' => "size=300M,mode=0700,uid=sssd,gid=sssd,rootcontext=system_u:object_r:sssd_var_lib_t:s0",
  },
}
```

* https://www.freedesktop.org/software/systemd/man/latest/systemd.mount.html
