### PR TITLE
Drop EOL RHEL, CentOS, Fedora, VirtuozzoLinux versions

### DIFF
--- a/data/RedHat-family-7.yaml
+++ b/data/RedHat-family-7.yaml
@@ -1,8 +1,0 @@
----
-systemd::nspawn_package: ~
-
-systemd::accounting:
-  DefaultCPUAccounting: 'yes'
-  DefaultBlockIOAccounting: 'yes'
-  DefaultMemoryAccounting: 'yes'
-  DefaultTasksAccounting: 'yes'

--- a/data/VirtuozzoLinux-7.yaml
+++ b/data/VirtuozzoLinux-7.yaml
@@ -1,6 +1,0 @@
----
-systemd::accounting:
-  DefaultCPUAccounting: 'yes'
-  DefaultBlockIOAccounting: 'yes'
-  DefaultMemoryAccounting: 'yes'
-  DefaultTasksAccounting: 'yes'

--- a/metadata.json
+++ b/metadata.json
@@ -43,22 +43,13 @@
     {
       "operatingsystem": "RedHat",
       "operatingsystemrelease": [
-        "7",
         "8",
         "9"
       ]
     },
     {
-      "operatingsystem": "VirtuozzoLinux",
-      "operatingsystemrelease": [
-        "7"
-      ]
-    },
-    {
       "operatingsystem": "CentOS",
       "operatingsystemrelease": [
-        "7",
-        "8",
         "9"
       ]
     },
@@ -92,8 +83,6 @@
     {
       "operatingsystem": "Fedora",
       "operatingsystemrelease": [
-        "37",
-        "38",
         "40"
       ]
     }

--- a/spec/acceptance/nspwan_spec.rb
+++ b/spec/acceptance/nspwan_spec.rb
@@ -3,7 +3,7 @@
 require 'spec_helper_acceptance'
 
 describe 'systemd with manage_nspawn true' do
-  machinectl = (fact('os.name') == 'Debian') && %w[10 11].include?(fact('os.release.major')) ? '/bin/machinectl' : '/usr/bin/machinectl'
+  machinectl = (fact('os.name') == 'Debian') && (fact('os.release.major') == '11') ? '/bin/machinectl' : '/usr/bin/machinectl'
 
   context 'configure nspawn' do
     let(:manifest) do

--- a/spec/defines/daemon_reload_spec.rb
+++ b/spec/defines/daemon_reload_spec.rb
@@ -26,11 +26,7 @@ describe 'systemd::daemon_reload' do
             case [facts[:os]['name'], facts[:os]['family'], facts[:os]['release']['major']]
             when %w[Debian Debian 11],
               ['Ubuntu', 'Debian', '20.04'],
-              %w[VirtuozzoLinux RedHat 7],
               %w[AlmaLinux RedHat 8],
-              %w[CentOS RedHat 7],
-              %w[CentOS RedHat 8],
-              %w[RedHat RedHat 7],
               %w[RedHat RedHat 8],
               %w[Rocky RedHat 8],
               %w[OracleLinux RedHat 8]


### PR DESCRIPTION
* VirtuozzoLinux 7
* Fedora 38, 39
* Centos 7, 8
* RHEL 7