### PR TITLE
Support management of Swap unit files

### DIFF
--- a/manifests/manage_dropin.pp
+++ b/manifests/manage_dropin.pp
@@ -89,6 +89,7 @@
 # @param path_entry key value pairs for [Path] section of the unit file
 # @param socket_entry key value pairs for the [Socket] section of the unit file
 # @param mount_entry key value pairs for the [Mount] section of the unit file
+# @param swap_entry key value pairs for the [Swap] section of the unit file
 #
 define systemd::manage_dropin (
   Systemd::Unit                    $unit,
@@ -110,6 +111,7 @@ define systemd::manage_dropin (
   Optional[Systemd::Unit::Path]    $path_entry              = undef,
   Optional[Systemd::Unit::Socket]  $socket_entry            = undef,
   Optional[Systemd::Unit::Mount]   $mount_entry             = undef,
+  Optional[Systemd::Unit::Swap]    $swap_entry              = undef,
 ) {
   if $timer_entry and $unit !~ Pattern['^[^/]+\.timer'] {
     fail("Systemd::Manage_dropin[${name}]: for unit ${unit} timer_entry is only valid for timer units")
@@ -129,6 +131,10 @@ define systemd::manage_dropin (
 
   if $mount_entry and $unit !~ Pattern['^[^/]+\.mount'] {
     fail("Systemd::Manage_dropin[${name}]: for unit ${unit} mount_entry is only valid for mount units")
+  }
+
+  if $swap_entry and $unit !~ Pattern['^[^/]+\.swap'] {
+    fail("Systemd::Manage_dropin[${name}]: for unit ${unit} mount_entry is only valid for swap units")
   }
 
   systemd::dropin_file { $name:
@@ -152,6 +158,7 @@ define systemd::manage_dropin (
         'path_entry'    => $path_entry,
         'socket_entry'  => $socket_entry,
         'mount_entry'   => $mount_entry,
+        'swap_entry'    => $swap_entry,
     }),
   }
 }

--- a/spec/defines/manage_dropin_spec.rb
+++ b/spec/defines/manage_dropin_spec.rb
@@ -134,6 +134,26 @@ describe 'systemd::manage_dropin' do
           end
         end
 
+        context 'on a swap unit' do
+          let(:params) do
+            {
+              unit: 'file.swap',
+              swap_entry: {
+                'Priority' => 10,
+              }
+            }
+          end
+
+          it { is_expected.to compile.with_all_deps }
+
+          it {
+            is_expected.to contain_systemd__dropin_file('foobar.conf').
+              with_unit('file.swap').
+              with_content(%r{^\[Swap\]$}).
+              with_content(%r{^Priority=10$})
+          }
+        end
+
         context 'on a timer' do
           let(:params) do
             {

--- a/spec/defines/manage_unit_spec.rb
+++ b/spec/defines/manage_unit_spec.rb
@@ -127,6 +127,35 @@ describe 'systemd::manage_unit' do
           }
         end
 
+        context 'on a swap' do
+          let(:title) { 'file.swap' }
+
+          let(:params) do
+            {
+              unit_entry: {
+                Description: 'Add swap from a file',
+              },
+              swap_entry: {
+                'What' => '/file',
+                'TimeoutSec' => 100,
+                'Options' => 'trim',
+                'Priority' => 10,
+              },
+            }
+          end
+
+          it { is_expected.to compile.with_all_deps }
+
+          it {
+            is_expected.to contain_systemd__unit_file('file.swap').
+              with_content(%r{^\[Swap\]$}).
+              with_content(%r{^What=/file$}).
+              with_content(%r{^TimeoutSec=100$}).
+              with_content(%r{^Options=trim$}).
+              with_content(%r{^Priority=10$})
+          }
+        end
+
         context 'on a timer' do
           let(:title) { 'winter.timer' }
 

--- a/spec/type_aliases/systemd_unit_swap_spec.rb
+++ b/spec/type_aliases/systemd_unit_swap_spec.rb
@@ -1,0 +1,28 @@
+# frozen_string_literal: true
+
+require 'spec_helper'
+
+describe 'Systemd::Unit::Swap' do
+  context 'with a key of What can have thing to mount' do
+    it { is_expected.to allow_value({ 'What' => '/tmpfs' }) }
+    it { is_expected.to allow_value({ 'What' => '/dev/vda1' }) }
+  end
+
+  context 'with a key of Options' do
+    it { is_expected.to allow_value({ 'Options' => 'trim' }) }
+  end
+
+  context 'with a key of Priority' do
+    it { is_expected.to allow_value({ 'Priority' => 10 }) }
+  end
+
+  context 'with a key of TimeoutSec can have a mode of' do
+    it { is_expected.to allow_value({ 'TimeoutSec' => '100' }) }
+    it { is_expected.to allow_value({ 'TimeoutSec' => '5min 20s' }) }
+    it { is_expected.to allow_value({ 'TimeoutSec' => '' }) }
+  end
+
+  context 'with a key of Where' do
+    it { is_expected.not_to allow_value({ 'Where' => '/mnt/foo' }) }
+  end
+end

--- a/templates/unit_file.epp
+++ b/templates/unit_file.epp
@@ -21,9 +21,9 @@
    'Timer',
    'Path',
    'Socket',
-   'Install',
    'Mount',
    'Swap',
+   'Install',
 ]
 
 # Directives which are pair of items to be expressed as a space seperated pair.

--- a/templates/unit_file.epp
+++ b/templates/unit_file.epp
@@ -7,6 +7,7 @@
  Optional[Hash] $path_entry,
  Optional[Hash] $socket_entry,
  Optional[Hash] $mount_entry,
+ Optional[Hash] $swap_entry,
 | -%>
 <%-
 
@@ -22,6 +23,7 @@
    'Socket',
    'Install',
    'Mount',
+   'Swap',
 ]
 
 # Directives which are pair of items to be expressed as a space seperated pair.

--- a/types/unit/swap.pp
+++ b/types/unit/swap.pp
@@ -1,0 +1,11 @@
+# @summary Possible keys for the [Swap] section of a unit file
+# @see https://www.freedesktop.org/software/systemd/man/latest/systemd.swap.html
+#
+type Systemd::Unit::Swap = Struct[
+  {
+    Optional['What']          => String[1],
+    Optional['Options']       => String[1],
+    Optional['Priority']      => Integer,
+    Optional['TimeoutSec']    => Variant[Integer[0],String[0]]
+  }
+]


### PR DESCRIPTION
#### Pull Request (PR) description

Let `.swap` unit files be managed with `systemd::manage_dropin` and `systemd::manage_unit`.

For example:

```puppet
systemd::manage_unit{'swapfile.swap':
  ensure        => 'present',
  active        => true,
  enable        => true,
  unit_entry    => {
    'Description' => 'Enable a swapfile at /swapfile',
  }
  swap_entry    => {
    'What' => '/swapfile',
  }
  install_entry => {
    'WantedBy' => 'multi-user.target',
  },
}
```

* https://www.freedesktop.org/software/systemd/man/latest/systemd.swap.html

