### PR TITLE
Correct UMask in mkswap example

### DIFF
--- a/REFERENCE.md
+++ b/REFERENCE.md
@@ -1415,7 +1415,8 @@ systemd::manage_unit{'mkswap.service':
     'ConditionPathExists' => '!/swapfile',
   },
   service_entry => {
-    'type'      => 'oneshot',
+    'Type'      => 'oneshot',
+    'UMask'     => '0177',
     'ExecStart' => [
       '/usr/bin/dd if=/dev/zero of=/swapfile bs=1024 count=1000',
       '/usr/sbin/mkswap /swapfile',

--- a/manifests/manage_unit.pp
+++ b/manifests/manage_unit.pp
@@ -110,7 +110,8 @@
 #      'ConditionPathExists' => '!/swapfile',
 #    },
 #    service_entry => {
-#      'type'      => 'oneshot',
+#      'Type'      => 'oneshot',
+#      'UMask'     => '0177',
 #      'ExecStart' => [
 #        '/usr/bin/dd if=/dev/zero of=/swapfile bs=1024 count=1000',
 #        '/usr/sbin/mkswap /swapfile',


### PR DESCRIPTION
#### Pull Request (PR) description

Without a correct UMask set the `mkswap` example fails due to permissions being too relaxed.

