### PR TITLE
Enclose the 'include systemd' in the module

### DIFF
--- a/manifests/daemon_reload.pp
+++ b/manifests/daemon_reload.pp
@@ -31,7 +31,9 @@ define systemd::daemon_reload (
   Boolean $enable = true,
   Optional[String[1]] $user = undef,
 ) {
-  include systemd
+  if !defined(Class['systemd']) {
+    include systemd
+  }
 
   if $enable {
     if $user {

--- a/manifests/dropin_file.pp
+++ b/manifests/dropin_file.pp
@@ -35,7 +35,9 @@ define systemd::dropin_file (
   Boolean                                     $notify_service          = true,
   Boolean                                     $daemon_reload           = true,
 ) {
-  include systemd
+  if !defined(Class['systemd']) {
+    include systemd
+  }
 
   if $target {
     $_ensure = 'link'

--- a/manifests/network.pp
+++ b/manifests/network.pp
@@ -24,7 +24,9 @@ define systemd::network (
   Boolean                        $show_diff       = true,
   Boolean                        $restart_service = true,
 ) {
-  include systemd
+  if !defined(Class['systemd']) {
+    include systemd
+  }
 
   if $restart_service and $systemd::manage_networkd and $facts['systemd_internal_services'] and $facts['systemd_internal_services']['systemd-networkd.service'] {
     $notify = Service['systemd-networkd']

--- a/manifests/service_limits.pp
+++ b/manifests/service_limits.pp
@@ -41,7 +41,9 @@ define systemd::service_limits (
     fail('The restart_service parameter is deprecated and only false is a valid value')
   }
 
-  include systemd
+  if !defined(Class['systemd']) {
+    include systemd
+  }
 
   if $name !~ Pattern['^.+\.(service|socket|mount|swap)$'] {
     fail('$name must match Pattern["^.+\.(service|socket|mount|swap)$"]')

--- a/manifests/unit_file.pp
+++ b/manifests/unit_file.pp
@@ -86,7 +86,9 @@ define systemd::unit_file (
   Boolean                                  $daemon_reload = true,
   Boolean                                  $service_restart = true,
 ) {
-  include systemd
+  if !defined(Class['systemd']) {
+    include systemd
+  }
 
   assert_type(Systemd::Unit, $name)
 


### PR DESCRIPTION
When using a different module to call the systemd
class and also using systemd::unit_file you get a
duplicate resource. By this 'if !defined' this is
solved. Issue #505

<!--
Thank you for contributing to this project!

- This project has a Contributor Code of Conduct: https://voxpupuli.org/coc/
- Please check that here is no existing issue or PR that addresses your problem.
- Our vulnerabilities reporting process is at https://voxpupuli.org/security/

-->
#### Pull Request (PR) description
<!--
Replace this comment with a description of your pull request.
-->

#### This Pull Request (PR) fixes the following issues
<!--
Replace this comment with the list of issues or n/a.
Use format:
Fixes #123
Fixes #124
-->
