### PR TITLE
unit_file: allow arbitrary symlink targets

### DIFF
--- a/manifests/unit_file.pp
+++ b/manifests/unit_file.pp
@@ -73,7 +73,7 @@ define systemd::unit_file (
   Stdlib::Absolutepath                     $path      = '/etc/systemd/system',
   Optional[Variant[String, Sensitive[String], Deferred]] $content = undef,
   Optional[String]                         $source    = undef,
-  Optional[Stdlib::Absolutepath]           $target    = undef,
+  Optional[String]                         $target    = undef,
   String                                   $owner     = 'root',
   String                                   $group     = 'root',
   String                                   $mode      = '0444',


### PR DESCRIPTION
Absolutepath is exactly what it says: it forces the link target to be an absolute path, that is to start with a slash (`/`). But I actually *want* to have relative symlinks.

This is particularly useful when doing a @.service template where the instance refers to the template, often in the same directory.

This, for example, should be allowed:

    systemd::unit_file { "pgbackrest-backup-${kind}@${shortname}.service":
      enable => false,
      active => false,
      target => "pgbackrest-backup-${kind}@.service",
    }

Yet it currently crashes with:

    Error: Could not retrieve catalog from remote server: Error 500 on SERVER: Server Error: Evaluation Error: Error while evaluating a Resource Statement, Systemd::Unit_file[pgbackrest-backup-full@rude.service]: parameter 'target' expects a Stdlib::Absolutepath = Variant[Stdlib::Windowspath = Pattern[/\A(([a-zA-Z]:[\\\/])|([\\\/][\\\/][^\\\/]+[\\\/][^\\\/]+)|([\\\/][\\\/]\?[\\\/][^\\\/]+)).*\z/], Stdlib::Unixpath = Pattern[/\A\/([^\n\/\0]+\/*)*\z/]] value, got String (file: /etc/puppet/code/environments/prom_module_upgrade/3rdparty/modules/pgbackrest/manifests/repository/stanza.pp, line: 77) on node backup-storage-01.torproject.org

I don't know of another way to fix this than to make this a proper string.

Closes: #510