### PR TITLE
Add support for .link units and dropins

### DIFF
--- a/REFERENCE.md
+++ b/REFERENCE.md
@@ -80,6 +80,8 @@
 * [`Systemd::Unit::Amount`](#Systemd--Unit--Amount): Systemd definition of amount, often bytes or united bytes
 * [`Systemd::Unit::AmountOrPercent`](#Systemd--Unit--AmountOrPercent): Systemd definition of amount, often bytes or united bytes
 * [`Systemd::Unit::Install`](#Systemd--Unit--Install): Possible keys for the [Install] section of a unit file
+* [`Systemd::Unit::Link`](#Systemd--Unit--Link): Possible keys for the [Link] section of a unit file
+* [`Systemd::Unit::Match`](#Systemd--Unit--Match): Possible keys for the [Match] section of a unit file
 * [`Systemd::Unit::Mount`](#Systemd--Unit--Mount): Possible keys for the [Mount] section of a unit file
 * [`Systemd::Unit::Path`](#Systemd--Unit--Path): Possible keys for the [Path] section of a unit file
 * [`Systemd::Unit::Percent`](#Systemd--Unit--Percent): Systemd definition of a percentage
@@ -1127,6 +1129,8 @@ The following parameters are available in the `systemd::manage_dropin` defined t
 * [`socket_entry`](#-systemd--manage_dropin--socket_entry)
 * [`mount_entry`](#-systemd--manage_dropin--mount_entry)
 * [`swap_entry`](#-systemd--manage_dropin--swap_entry)
+* [`match_entry`](#-systemd--manage_dropin--match_entry)
+* [`link_entry`](#-systemd--manage_dropin--link_entry)
 
 ##### <a name="-systemd--manage_dropin--unit"></a>`unit`
 
@@ -1283,6 +1287,22 @@ Default value: `undef`
 Data type: `Optional[Systemd::Unit::Swap]`
 
 key value pairs for the [Swap] section of the unit file
+
+Default value: `undef`
+
+##### <a name="-systemd--manage_dropin--match_entry"></a>`match_entry`
+
+Data type: `Optional[Systemd::Unit::Match]`
+
+kev value pairs for [Match] section of the unit file.
+
+Default value: `undef`
+
+##### <a name="-systemd--manage_dropin--link_entry"></a>`link_entry`
+
+Data type: `Optional[Systemd::Unit::Link]`
+
+kev value pairs for [Link] section of the unit file.
 
 Default value: `undef`
 
@@ -1460,6 +1480,8 @@ The following parameters are available in the `systemd::manage_unit` defined typ
 * [`socket_entry`](#-systemd--manage_unit--socket_entry)
 * [`mount_entry`](#-systemd--manage_unit--mount_entry)
 * [`swap_entry`](#-systemd--manage_unit--swap_entry)
+* [`match_entry`](#-systemd--manage_unit--match_entry)
+* [`link_entry`](#-systemd--manage_unit--link_entry)
 
 ##### <a name="-systemd--manage_unit--name"></a>`name`
 
@@ -1640,6 +1662,22 @@ Default value: `undef`
 Data type: `Optional[Systemd::Unit::Swap]`
 
 kev value pairs for [Swap] section of the unit file.
+
+Default value: `undef`
+
+##### <a name="-systemd--manage_unit--match_entry"></a>`match_entry`
+
+Data type: `Optional[Systemd::Unit::Match]`
+
+kev value pairs for [Match] section of the unit file.
+
+Default value: `undef`
+
+##### <a name="-systemd--manage_unit--link_entry"></a>`link_entry`
+
+Data type: `Optional[Systemd::Unit::Link]`
+
+kev value pairs for [Link] section of the unit file.
 
 Default value: `undef`
 
@@ -3123,7 +3161,7 @@ custom datatype that validates different filenames for systemd units and unit te
 * **See also**
   * https://www.freedesktop.org/software/systemd/man/systemd.unit.html
 
-Alias of `Pattern[/^[a-zA-Z0-9:\-_.\\@%]+\.(service|socket|device|mount|automount|swap|target|path|timer|slice|scope)$/]`
+Alias of `Pattern[/^[a-zA-Z0-9:\-_.\\@%]+\.(service|socket|device|mount|automount|swap|target|path|timer|slice|scope|link)$/]`
 
 ### <a name="Systemd--Unit--Amount"></a>`Systemd::Unit::Amount`
 
@@ -3163,6 +3201,36 @@ Struct[{
     Optional['WantedBy']   => Variant[Enum[''],Systemd::Unit,Array[Variant[Enum[''],Systemd::Unit],1]],
     Optional['RequiredBy'] => Variant[Enum[''],Systemd::Unit,Array[Variant[Enum[''],Systemd::Unit],1]],
     Optional['Also']       => Variant[Enum[''],Systemd::Unit,Array[Variant[Enum[''],Systemd::Unit],1]],
+  }]
+```
+
+### <a name="Systemd--Unit--Link"></a>`Systemd::Unit::Link`
+
+Possible keys for the [Link] section of a unit file
+
+* **See also**
+  * https://www.freedesktop.org/software/systemd/man/latest/systemd.link.html
+
+Alias of
+
+```puppet
+Struct[{
+    Optional['MTUBytes']    => Integer[0],
+  }]
+```
+
+### <a name="Systemd--Unit--Match"></a>`Systemd::Unit::Match`
+
+Possible keys for the [Match] section of a unit file
+
+* **See also**
+  * https://www.freedesktop.org/software/systemd/man/latest/systemd.link.html
+
+Alias of
+
+```puppet
+Struct[{
+    Optional['Driver'] => String[1],
   }]
 ```
 

--- a/manifests/manage_dropin.pp
+++ b/manifests/manage_dropin.pp
@@ -90,6 +90,8 @@
 # @param socket_entry key value pairs for the [Socket] section of the unit file
 # @param mount_entry key value pairs for the [Mount] section of the unit file
 # @param swap_entry key value pairs for the [Swap] section of the unit file
+# @param match_entry kev value pairs for [Match] section of the unit file.
+# @param link_entry kev value pairs for [Link] section of the unit file.
 #
 define systemd::manage_dropin (
   Systemd::Unit                    $unit,
@@ -112,6 +114,8 @@ define systemd::manage_dropin (
   Optional[Systemd::Unit::Socket]  $socket_entry            = undef,
   Optional[Systemd::Unit::Mount]   $mount_entry             = undef,
   Optional[Systemd::Unit::Swap]    $swap_entry              = undef,
+  Optional[Systemd::Unit::Link]    $link_entry              = undef,
+  Optional[Systemd::Unit::Match]   $match_entry             = undef,
 ) {
   if $timer_entry and $unit !~ Pattern['^[^/]+\.timer'] {
     fail("Systemd::Manage_dropin[${name}]: for unit ${unit} timer_entry is only valid for timer units")
@@ -137,6 +141,14 @@ define systemd::manage_dropin (
     fail("Systemd::Manage_dropin[${name}]: for unit ${unit} mount_entry is only valid for swap units")
   }
 
+  if $link_entry and $unit !~ Pattern['^[^/]+\.link'] {
+    fail("Systemd::Manage_dropin[${name}]: for unit ${unit} link_entry is only valid for link units")
+  }
+
+  if $match_entry and $unit !~ Pattern['^[^/]+\.link'] {
+    fail("Systemd::Manage_dropin[${name}]: for unit ${unit} match_entry is only valid for link units")
+  }
+
   systemd::dropin_file { $name:
     ensure                  => $ensure,
     filename                => $filename,
@@ -159,6 +171,8 @@ define systemd::manage_dropin (
         'socket_entry'  => $socket_entry,
         'mount_entry'   => $mount_entry,
         'swap_entry'    => $swap_entry,
+        'match_entry'   => $match_entry,
+        'link_entry'    => $link_entry,
     }),
   }
 }

--- a/manifests/manage_unit.pp
+++ b/manifests/manage_unit.pp
@@ -154,6 +154,8 @@
 # @param socket_entry kev value paors for [Socket] section of the unit file.
 # @param mount_entry kev value pairs for [Mount] section of the unit file.
 # @param swap_entry kev value pairs for [Swap] section of the unit file.
+# @param match_entry kev value pairs for [Match] section of the unit file.
+# @param link_entry kev value pairs for [Link] section of the unit file.
 #
 define systemd::manage_unit (
   Enum['present', 'absent']                $ensure                  = 'present',
@@ -178,6 +180,8 @@ define systemd::manage_unit (
   Optional[Systemd::Unit::Socket]          $socket_entry            = undef,
   Optional[Systemd::Unit::Mount]           $mount_entry             = undef,
   Optional[Systemd::Unit::Swap]            $swap_entry              = undef,
+  Optional[Systemd::Unit::Link]            $link_entry              = undef,
+  Optional[Systemd::Unit::Match]           $match_entry             = undef,
 ) {
   assert_type(Systemd::Unit, $name)
 
@@ -203,6 +207,14 @@ define systemd::manage_unit (
 
   if $swap_entry and $name !~ Pattern['^[^/]+\.swap'] {
     fail("Systemd::Manage_unit[${name}]: swap_entry is only valid for swap units")
+  }
+
+  if $link_entry and $name !~ Pattern['^[^/]+\.link'] {
+    fail("Systemd::Manage_unit[${name}]: link_entry is only valid for link units")
+  }
+
+  if $match_entry and $name !~ Pattern['^[^/]+\.link'] {
+    fail("Systemd::Manage_unit[${name}]: mantch_entry is only valid for link units")
   }
 
   if $ensure != 'absent' and  $name =~ Pattern['^[^/]+\.service'] and !$service_entry {
@@ -232,6 +244,8 @@ define systemd::manage_unit (
         'socket_entry'  => $socket_entry,
         'mount_entry'   => $mount_entry,
         'swap_entry'    => $swap_entry,
+        'match_entry'   => $match_entry,
+        'link_entry'    => $link_entry,
     }),
   }
 }

--- a/spec/defines/manage_dropin_spec.rb
+++ b/spec/defines/manage_dropin_spec.rb
@@ -259,6 +259,31 @@ describe 'systemd::manage_dropin' do
               with_content(%r{^ListenMessageQueue=/panic$})
           }
         end
+
+        context 'on a link unit dropin' do
+          let(:params) do
+            {
+              unit: 'wireless.link',
+              match_entry: {
+                'Driver' => 'brcmsmac',
+              },
+              link_entry: {
+                'MTUBytes' => 1450,
+              }
+            }
+          end
+
+          it { is_expected.to compile.with_all_deps }
+
+          it {
+            is_expected.to contain_systemd__dropin_file('foobar.conf').
+              with_unit('wireless.link').
+              with_content(%r{^\[Match\]$}).
+              with_content(%r{^Driver=brcmsmac$}).
+              with_content(%r{^\[Link\]$}).
+              with_content(%r{^MTUBytes=1450$})
+          }
+        end
       end
     end
   end

--- a/spec/defines/manage_unit_spec.rb
+++ b/spec/defines/manage_unit_spec.rb
@@ -260,6 +260,30 @@ describe 'systemd::manage_unit' do
           }
         end
 
+        context 'on a link unit' do
+          let(:title) { '15-wireless.link' }
+          let(:params) do
+            {
+              match_entry: {
+                'Driver' => 'brcmsmac',
+              },
+              link_entry: {
+                'MTUBytes' => 1450,
+              }
+            }
+          end
+
+          it { is_expected.to compile.with_all_deps }
+
+          it {
+            is_expected.to contain_systemd__unit_file('15-wireless.link').
+              with_content(%r{^\[Match\]$}).
+              with_content(%r{^Driver=brcmsmac$}).
+              with_content(%r{^\[Link\]$}).
+              with_content(%r{^MTUBytes=1450$})
+          }
+        end
+
         context 'on a path unit' do
           let(:title) { 'etc-passwd.path' }
 

--- a/spec/type_aliases/systemd_unit_link_spec.rb
+++ b/spec/type_aliases/systemd_unit_link_spec.rb
@@ -1,0 +1,9 @@
+# frozen_string_literal: true
+
+require 'spec_helper'
+
+describe 'Systemd::Unit::Link' do
+  context 'with a key of What can have thing to link' do
+    it { is_expected.to allow_value({ 'MTUBytes' => 1024 }) }
+  end
+end

--- a/spec/type_aliases/systemd_unit_match_spec.rb
+++ b/spec/type_aliases/systemd_unit_match_spec.rb
@@ -1,0 +1,9 @@
+# frozen_string_literal: true
+
+require 'spec_helper'
+
+describe 'Systemd::Unit::Match' do
+  context 'with a key of What can have thing to link' do
+    it { is_expected.to allow_value({ 'Driver' => 'brcmsmac' }) }
+  end
+end

--- a/spec/type_aliases/unit_spec.rb
+++ b/spec/type_aliases/unit_spec.rb
@@ -6,6 +6,7 @@ describe 'Systemd::Unit' do
   context 'with a permitted unit name' do
     [
       'foo.service',
+      '25-wireless.link',
       'foo.socket',
       'atemplate@.service',
       'atemplate@instance.service',

--- a/templates/unit_file.epp
+++ b/templates/unit_file.epp
@@ -8,6 +8,8 @@
  Optional[Hash] $socket_entry,
  Optional[Hash] $mount_entry,
  Optional[Hash] $swap_entry,
+ Optional[Hash] $match_entry,
+ Optional[Hash] $link_entry,
 | -%>
 <%-
 
@@ -24,6 +26,8 @@
    'Mount',
    'Swap',
    'Install',
+   'Match',
+   'Link',
 ]
 
 # Directives which are pair of items to be expressed as a space seperated pair.

--- a/types/unit.pp
+++ b/types/unit.pp
@@ -1,3 +1,3 @@
 # @summary custom datatype that validates different filenames for systemd units and unit templates
 # @see https://www.freedesktop.org/software/systemd/man/systemd.unit.html
-type Systemd::Unit = Pattern[/^[a-zA-Z0-9:\-_.\\@%]+\.(service|socket|device|mount|automount|swap|target|path|timer|slice|scope)$/]
+type Systemd::Unit = Pattern[/^[a-zA-Z0-9:\-_.\\@%]+\.(service|socket|device|mount|automount|swap|target|path|timer|slice|scope|link)$/]

--- a/types/unit/link.pp
+++ b/types/unit/link.pp
@@ -1,0 +1,8 @@
+# @summary Possible keys for the [Link] section of a unit file
+# @see https://www.freedesktop.org/software/systemd/man/latest/systemd.link.html
+#
+type Systemd::Unit::Link = Struct[
+  {
+    Optional['MTUBytes']    => Integer[0],
+  }
+]

--- a/types/unit/match.pp
+++ b/types/unit/match.pp
@@ -1,0 +1,8 @@
+# @summary Possible keys for the [Match] section of a unit file
+# @see https://www.freedesktop.org/software/systemd/man/latest/systemd.link.html
+#
+type Systemd::Unit::Match = Struct[
+  {
+    Optional['Driver'] => String[1],
+  }
+]


### PR DESCRIPTION
#### Pull Request (PR) description

Addition of link unit support to `systemd::manage_unit` and `systemd::manage_dropin`.

* https://www.freedesktop.org/software/systemd/man/latest/systemd.link.html

This only adds a skeleton of the parameters that can be set.

More will be needed to be usable.

