### PR TITLE
Define `systemd::resolved_package` for Ubuntu 24.04

### DIFF
--- a/data/Ubuntu-24.04.yaml
+++ b/data/Ubuntu-24.04.yaml
@@ -1,0 +1,1 @@
+systemd::resolved_package: systemd-resolved

--- a/spec/acceptance/resolved_spec.rb
+++ b/spec/acceptance/resolved_spec.rb
@@ -3,7 +3,7 @@
 require 'spec_helper_acceptance'
 
 describe 'systemd with manage_resolved true' do
-  has_package = (fact('os.family') == 'RedHat' && fact('os.release.major') != '8') || (fact('os.name') == 'Debian' && fact('os.release.major').to_i >= 12)
+  has_package = (fact('os.family') == 'RedHat' && fact('os.release.major') != '8') || (fact('os.name') == 'Debian' && fact('os.release.major').to_i >= 12) || (fact('os.name') == 'Ubuntu' && fact('os.release.major').to_i >= 24)
 
   context 'configure systemd resolved' do
     it 'works idempotently with no errors' do

--- a/spec/classes/init_spec.rb
+++ b/spec/classes/init_spec.rb
@@ -47,7 +47,7 @@ describe 'systemd' do
             it { is_expected.not_to contain_package('systemd-networkd') }
           end
 
-          if (facts[:os]['family'] == 'RedHat' && facts[:os]['release']['major'] != '8') || (facts[:os]['name'] == 'Debian' && facts[:os]['release']['major'] == '12')
+          if (facts[:os]['family'] == 'RedHat' && facts[:os]['release']['major'] != '8') || (facts[:os]['name'] == 'Debian' && facts[:os]['release']['major'].to_i >= 12) || (facts[:os]['name'] == 'Ubuntu' && facts[:os]['release']['major'].to_i >= 24)
             it { is_expected.to contain_package('systemd-resolved') }
           else
             it { is_expected.not_to contain_package('systemd-resolved') }


### PR DESCRIPTION
Includes #524

`systemd-resolved` is in a separate package starting in Ubuntu 24.04, so we should define this in the hiera data (even though the `systemd` package recommends `systemd-resolved`, so normally the `systemd-resolved` package is installed anyway).