### PR TITLE
Ensure NSS libraries are installed when managing `systemd-resolved` on Debian family

### DIFF
--- a/REFERENCE.md
+++ b/REFERENCE.md
@@ -115,6 +115,7 @@ The following parameters are available in the `systemd` class:
 * [`manage_resolved`](#-systemd--manage_resolved)
 * [`resolved_ensure`](#-systemd--resolved_ensure)
 * [`resolved_package`](#-systemd--resolved_package)
+* [`resolved_libraries`](#-systemd--resolved_libraries)
 * [`manage_nspawn`](#-systemd--manage_nspawn)
 * [`nspawn_package`](#-systemd--nspawn_package)
 * [`dns`](#-systemd--dns)
@@ -252,6 +253,14 @@ Data type: `Optional[Enum['systemd-resolved']]`
 The name of a systemd sub package needed for systemd-resolved if one needs to be installed.
 
 Default value: `undef`
+
+##### <a name="-systemd--resolved_libraries"></a>`resolved_libraries`
+
+Data type: `Array[String[1]]`
+
+List of library packages needed for systemd-resolved.
+
+Default value: `[]`
 
 ##### <a name="-systemd--manage_nspawn"></a>`manage_nspawn`
 

--- a/data/Debian-family.yaml
+++ b/data/Debian-family.yaml
@@ -2,3 +2,7 @@
 systemd::nspawn_package: 'systemd-container'
 systemd::journal_upload::package_name: 'systemd-journal-remote'
 systemd::journal_remote::package_name: 'systemd-journal-remote'
+systemd::resolved_libraries:
+  - libnss-myhostname
+  - libnss-resolve
+  - libnss-systemd

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -31,6 +31,9 @@
 # @param resolved_package
 #   The name of a systemd sub package needed for systemd-resolved if one needs to be installed.
 #
+# @param resolved_libraries
+#   List of library packages needed for systemd-resolved.
+#
 # @param manage_nspawn
 #   Manage the systemd-nspawn@service and machinectl subsystem.
 #
@@ -260,6 +263,7 @@ class systemd (
   Stdlib::CreateResources                             $unit_files = {},
   Boolean                                             $manage_resolved = false,
   Optional[Enum['systemd-resolved']]                  $resolved_package = undef,
+  Array[String[1]]                                    $resolved_libraries = [],
   Enum['stopped','running']                           $resolved_ensure = 'running',
   Optional[Variant[Array[String],String]]             $dns = undef,
   Optional[Variant[Array[String],String]]             $fallback_dns = undef,

--- a/manifests/install.pp
+++ b/manifests/install.pp
@@ -14,9 +14,17 @@ class systemd::install {
     }
   }
 
-  if $systemd::manage_resolved and $systemd::resolved_package {
-    package { $systemd::resolved_package:
-      ensure => present,
+  if $systemd::manage_resolved {
+    if $systemd::resolved_package {
+      package { $systemd::resolved_package:
+        ensure => installed,
+      }
+    }
+
+    $systemd::resolved_libraries.each |String[1] $pkg| {
+      package { $pkg:
+        ensure => installed,
+      }
     }
   }
 

--- a/spec/acceptance/resolved_spec.rb
+++ b/spec/acceptance/resolved_spec.rb
@@ -25,6 +25,16 @@ describe 'systemd with manage_resolved true' do
     end
 
     it { expect(package('systemd-resolved')).to be_installed } if has_package
+
+    if fact('os.family') == 'Debian'
+      %w[
+        myhostname
+        resolve
+        systemd
+      ].each do |pkg|
+        it { expect(package("libnss-#{pkg}")).to be_installed }
+      end
+    end
   end
 
   context 'configure systemd stopped' do

--- a/spec/classes/init_spec.rb
+++ b/spec/classes/init_spec.rb
@@ -52,6 +52,17 @@ describe 'systemd' do
           else
             it { is_expected.not_to contain_package('systemd-resolved') }
           end
+
+          if facts[:os]['family'] == 'Debian'
+            %w[
+              myhostname
+              resolve
+              systemd
+            ].each do |pkg|
+              it { is_expected.to contain_package("libnss-#{pkg}") }
+            end
+          end
+
           context 'with manage_resolv_conf false' do
             let(:params) { super().merge(manage_resolv_conf: false) }
 


### PR DESCRIPTION
#### Pull Request (PR) description

Ensure Name Service Switch (NSS) libraries are installed when managing `systemd-resolved` on Debian family.

#### This Pull Request (PR) fixes the following issues
Fixes #526
