### PR TITLE
Allow `OOMScoreAdjust` within Mount, Socket, Swap Units

### DIFF
--- a/REFERENCE.md
+++ b/REFERENCE.md
@@ -3186,16 +3186,17 @@ Alias of
 
 ```puppet
 Struct[{
-    Optional['What']          => String[1],
-    Optional['Where']         => Stdlib::Unixpath,
-    Optional['Type']          => String[1],
-    Optional['Options']       => String[1],
-    Optional['SloppyOptions'] => Boolean,
-    Optional['LazyUnmount']   => Boolean,
-    Optional['ReadWriteOnly'] => Boolean,
-    Optional['ForceUnmount']  => Boolean,
-    Optional['DirectoryMode'] => Stdlib::Filemode,
-    Optional['TimeoutSec']    => String[0],
+    Optional['What']           => String[1],
+    Optional['Where']          => Stdlib::Unixpath,
+    Optional['Type']           => String[1],
+    Optional['Options']        => String[1],
+    Optional['SloppyOptions']  => Boolean,
+    Optional['LazyUnmount']    => Boolean,
+    Optional['ReadWriteOnly']  => Boolean,
+    Optional['ForceUnmount']   => Boolean,
+    Optional['DirectoryMode']  => Stdlib::Filemode,
+    Optional['TimeoutSec']     => String[0],
+    Optional['OOMScoreAdjust'] => Integer[-1000,1000],
   }]
 ```
 
@@ -3504,6 +3505,7 @@ Struct[{
     Optional['FileDescriptorName']      => String[1,255],
     Optional['TriggerLimitIntervalSec'] => String[1],
     Optional['TriggerLimitBurst']       => Integer[0],
+    Optional['OOMScoreAdjust']          => Integer[-1000,1000],
   }]
 ```
 
@@ -3518,10 +3520,11 @@ Alias of
 
 ```puppet
 Struct[{
-    Optional['What']          => String[1],
-    Optional['Options']       => String[1],
-    Optional['Priority']      => Integer,
-    Optional['TimeoutSec']    => Variant[Integer[0],String[0]]
+    Optional['What']           => String[1],
+    Optional['Options']        => String[1],
+    Optional['Priority']       => Integer,
+    Optional['TimeoutSec']     => Variant[Integer[0],String[0]],
+    Optional['OOMScoreAdjust'] => Integer[-1000,1000],
   }]
 ```
 

--- a/spec/type_aliases/systemd_unit_mount_spec.rb
+++ b/spec/type_aliases/systemd_unit_mount_spec.rb
@@ -39,4 +39,13 @@ describe 'Systemd::Unit::Mount' do
       it { is_expected.to allow_value({ assert => true }) }
     end
   end
+
+  context 'with a key of OOMScoreAdjust' do
+    it {
+      is_expected.to allow_value({ 'OOMScoreAdjust' => 999 })
+      is_expected.to allow_value({ 'OOMScoreAdjust' => -999 })
+      is_expected.not_to allow_value({ 'OOMScoreAdjust' => 1005 })
+      is_expected.not_to allow_value({ 'OOMScoreAdjust' => '10' })
+    }
+  end
 end

--- a/spec/type_aliases/systemd_unit_socket_spec.rb
+++ b/spec/type_aliases/systemd_unit_socket_spec.rb
@@ -17,4 +17,13 @@ describe 'Systemd::Unit::Socket' do
       it { is_expected.not_to allow_value({ assert => 'mything' }) }
     end
   end
+
+  context 'with a key of OOMScoreAdjust' do
+    it {
+      is_expected.to allow_value({ 'OOMScoreAdjust' => 999 })
+      is_expected.to allow_value({ 'OOMScoreAdjust' => -999 })
+      is_expected.not_to allow_value({ 'OOMScoreAdjust' => 1005 })
+      is_expected.not_to allow_value({ 'OOMScoreAdjust' => '10' })
+    }
+  end
 end

--- a/spec/type_aliases/systemd_unit_swap_spec.rb
+++ b/spec/type_aliases/systemd_unit_swap_spec.rb
@@ -25,4 +25,13 @@ describe 'Systemd::Unit::Swap' do
   context 'with a key of Where' do
     it { is_expected.not_to allow_value({ 'Where' => '/mnt/foo' }) }
   end
+
+  context 'with a key of OOMScoreAdjust' do
+    it {
+      is_expected.to allow_value({ 'OOMScoreAdjust' => 999 })
+      is_expected.to allow_value({ 'OOMScoreAdjust' => -999 })
+      is_expected.not_to allow_value({ 'OOMScoreAdjust' => 1005 })
+      is_expected.not_to allow_value({ 'OOMScoreAdjust' => '10' })
+    }
+  end
 end

--- a/types/unit/mount.pp
+++ b/types/unit/mount.pp
@@ -3,15 +3,16 @@
 #
 type Systemd::Unit::Mount = Struct[
   {
-    Optional['What']          => String[1],
-    Optional['Where']         => Stdlib::Unixpath,
-    Optional['Type']          => String[1],
-    Optional['Options']       => String[1],
-    Optional['SloppyOptions'] => Boolean,
-    Optional['LazyUnmount']   => Boolean,
-    Optional['ReadWriteOnly'] => Boolean,
-    Optional['ForceUnmount']  => Boolean,
-    Optional['DirectoryMode'] => Stdlib::Filemode,
-    Optional['TimeoutSec']    => String[0],
+    Optional['What']           => String[1],
+    Optional['Where']          => Stdlib::Unixpath,
+    Optional['Type']           => String[1],
+    Optional['Options']        => String[1],
+    Optional['SloppyOptions']  => Boolean,
+    Optional['LazyUnmount']    => Boolean,
+    Optional['ReadWriteOnly']  => Boolean,
+    Optional['ForceUnmount']   => Boolean,
+    Optional['DirectoryMode']  => Stdlib::Filemode,
+    Optional['TimeoutSec']     => String[0],
+    Optional['OOMScoreAdjust'] => Integer[-1000,1000],
   }
 ]

--- a/types/unit/socket.pp
+++ b/types/unit/socket.pp
@@ -61,5 +61,6 @@ type Systemd::Unit::Socket = Struct[
     Optional['FileDescriptorName']      => String[1,255],
     Optional['TriggerLimitIntervalSec'] => String[1],
     Optional['TriggerLimitBurst']       => Integer[0],
+    Optional['OOMScoreAdjust']          => Integer[-1000,1000],
   }
 ]

--- a/types/unit/swap.pp
+++ b/types/unit/swap.pp
@@ -3,9 +3,10 @@
 #
 type Systemd::Unit::Swap = Struct[
   {
-    Optional['What']          => String[1],
-    Optional['Options']       => String[1],
-    Optional['Priority']      => Integer,
-    Optional['TimeoutSec']    => Variant[Integer[0],String[0]]
+    Optional['What']           => String[1],
+    Optional['Options']        => String[1],
+    Optional['Priority']       => Integer,
+    Optional['TimeoutSec']     => Variant[Integer[0],String[0]],
+    Optional['OOMScoreAdjust'] => Integer[-1000,1000],
   }
 ]


### PR DESCRIPTION
#### Pull Request (PR) description

Allow OOMScoreAdjust to be added to `[Mount]`, `[Socket]` and `[Swap]` unit sections.

e.g.

```puppet
systemd::manage_dropin{ 'nokill.conf':
  ensure      => present,
  unit        => 'home.mount',
  mount_entry => {
   'OOMScoreAdjust' => -1000,
  },
}
```

* https://www.freedesktop.org/software/systemd/man/latest/systemd.exec.html#Description

#### This Pull Request (PR) fixes the following issues

* Fixes #521 
