### PR TITLE
Add `CPUSchedulingPolicy` for service entries

### DIFF
--- a/REFERENCE.md
+++ b/REFERENCE.md
@@ -3269,6 +3269,7 @@ Struct[{
     Optional['KillSignal']                => Pattern[/^SIG[A-Z]+$/],
     Optional['KillMode']                  => Enum['control-group', 'mixed', 'process', 'none'],
     Optional['Nice']                      => Variant[String[0,0],Integer[-20,19]],
+    Optional['CPUSchedulingPolicy']       => Enum['','batch','fifo','idle','other','rr'],
     Optional['IOSchedulingClass']         => Enum['','realtime','best-effort','idle'],
     Optional['IOSchedulingPriority']      => Variant[String[0,0],Integer[0,7]],
     Optional['SyslogIdentifier']          => String,

--- a/spec/type_aliases/systemd_unit_service_spec.rb
+++ b/spec/type_aliases/systemd_unit_service_spec.rb
@@ -76,6 +76,10 @@ describe 'Systemd::Unit::Service' do
   it { is_expected.to allow_value({ 'Nice' => 19 }) }
   it { is_expected.not_to allow_value({ 'Nice' => '0' }) }
 
+  it { is_expected.to allow_value({ 'CPUSchedulingPolicy' => 'idle' }) }
+  it { is_expected.to allow_value({ 'CPUSchedulingPolicy' => '' }) }
+  it { is_expected.not_to allow_value({ 'CPUSchedulingPolicy' => 'best-effort' }) }
+
   it { is_expected.to allow_value({ 'IOSchedulingClass' => 'best-effort' }) }
   it { is_expected.to allow_value({ 'IOSchedulingClass' => '' }) }
   it { is_expected.not_to allow_value({ 'IOSchedulingClass' => 'random' }) }

--- a/types/unit/service.pp
+++ b/types/unit/service.pp
@@ -27,6 +27,7 @@ type Systemd::Unit::Service = Struct[
     Optional['KillSignal']                => Pattern[/^SIG[A-Z]+$/],
     Optional['KillMode']                  => Enum['control-group', 'mixed', 'process', 'none'],
     Optional['Nice']                      => Variant[String[0,0],Integer[-20,19]],
+    Optional['CPUSchedulingPolicy']       => Enum['','batch','fifo','idle','other','rr'],
     Optional['IOSchedulingClass']         => Enum['','realtime','best-effort','idle'],
     Optional['IOSchedulingPriority']      => Variant[String[0,0],Integer[0,7]],
     Optional['SyslogIdentifier']          => String,


### PR DESCRIPTION
<!--
Thank you for contributing to this project!

- This project has a Contributor Code of Conduct: https://voxpupuli.org/coc/
- Please check that here is no existing issue or PR that addresses your problem.
- Our vulnerabilities reporting process is at https://voxpupuli.org/security/

-->
#### Pull Request (PR) description
Add another key that is supported for systemd services.

#### This Pull Request (PR) fixes the following issues
<!--
Replace this comment with the list of issues or n/a.
Use format:
Fixes #123
Fixes #124
-->
