### PR TITLE
Add defaults for RHEL10

### DIFF
--- a/data/RedHat-family-10.yaml
+++ b/data/RedHat-family-10.yaml
@@ -1,0 +1,10 @@
+---
+systemd::oomd_package: 'systemd-oomd'
+
+systemd::accounting:
+  DefaultCPUAccounting: 'yes'
+  DefaultBlockIOAccounting: 'yes'
+  DefaultMemoryAccounting: 'yes'
+  DefaultTasksAccounting: 'yes'
+  DefaultIOAccounting: 'yes'
+  DefaultIPAccounting: 'yes'


### PR DESCRIPTION
<!--
Thank you for contributing to this project!

- This project has a Contributor Code of Conduct: https://voxpupuli.org/coc/
- Please check that here is no existing issue or PR that addresses your problem.
- Our vulnerabilities reporting process is at https://voxpupuli.org/security/

-->
#### Pull Request (PR) description
With RHEL10 due out in May, here are the defaults for puppet-systemd.

The testsuite doesn't yet recognize EL10, so I'm leaving it out of the metadata until we can prove it out with the test suite.