### PR TITLE
Add missing `Systemd::LogindSettings`

### DIFF
--- a/REFERENCE.md
+++ b/REFERENCE.md
@@ -2893,12 +2893,19 @@ Alias of
 
 ```puppet
 Struct[{
+    Optional['DesignatedMaintenanceTime']    => Variant[Systemd::Unit::Amount,Systemd::LogindSettings::Ensure],
     Optional['HandleHibernateKey']           => Variant[Enum['ignore','poweroff','reboot','halt','kexec','suspend','hibernate','hybrid-sleep','suspend-then-hibernate','lock'],Systemd::LogindSettings::Ensure],
+    Optional['HandleHibernateKeyLongPress']  => Variant[Enum['ignore','poweroff','reboot','halt','kexec','suspend','hibernate','hybrid-sleep','suspend-then-hibernate','lock'],Systemd::LogindSettings::Ensure],
     Optional['HandleLidSwitch']              => Variant[Enum['ignore','poweroff','reboot','halt','kexec','suspend','hibernate','hybrid-sleep','suspend-then-hibernate','lock'],Systemd::LogindSettings::Ensure],
     Optional['HandleLidSwitchDocked']        => Variant[Enum['ignore','poweroff','reboot','halt','kexec','suspend','hibernate','hybrid-sleep','suspend-then-hibernate','lock'],Systemd::LogindSettings::Ensure],
     Optional['HandleLidSwitchExternalPower'] => Variant[Enum['ignore','poweroff','reboot','halt','kexec','suspend','hibernate','hybrid-sleep','suspend-then-hibernate','lock'],Systemd::LogindSettings::Ensure],
     Optional['HandlePowerKey']               => Variant[Enum['ignore','poweroff','reboot','halt','kexec','suspend','hibernate','hybrid-sleep','suspend-then-hibernate','lock'],Systemd::LogindSettings::Ensure],
+    Optional['HandlePowerKeyLongPress']      => Variant[Enum['ignore','poweroff','reboot','halt','kexec','suspend','hibernate','hybrid-sleep','suspend-then-hibernate','lock'],Systemd::LogindSettings::Ensure],
+    Optional['HandleRebootKey']              => Variant[Enum['ignore','poweroff','reboot','halt','kexec','suspend','hibernate','hybrid-sleep','suspend-then-hibernate','lock'],Systemd::LogindSettings::Ensure],
+    Optional['HandleRebootKeyLongPress']     => Variant[Enum['ignore','poweroff','reboot','halt','kexec','suspend','hibernate','hybrid-sleep','suspend-then-hibernate','lock'],Systemd::LogindSettings::Ensure],
+    Optional['HandleSecureAttentionKey']     => Variant[Enum['ignore','poweroff','reboot','halt','kexec','suspend','hibernate','hybrid-sleep','suspend-then-hibernate','lock'],Systemd::LogindSettings::Ensure],
     Optional['HandleSuspendKey']             => Variant[Enum['ignore','poweroff','reboot','halt','kexec','suspend','hibernate','hybrid-sleep','suspend-then-hibernate','lock'],Systemd::LogindSettings::Ensure],
+    Optional['HandleSuspendKeyLongPress']    => Variant[Enum['ignore','poweroff','reboot','halt','kexec','suspend','hibernate','hybrid-sleep','suspend-then-hibernate','lock'],Systemd::LogindSettings::Ensure],
     Optional['HibernateKeyIgnoreInhibited']  => Variant[Enum['yes','no'],Systemd::LogindSettings::Ensure],
     Optional['HoldoffTimeoutSec']            => Variant[Integer,Systemd::LogindSettings::Ensure],
     Optional['IdleAction']                   => Variant[Enum['ignore','poweroff','reboot','halt','kexec','suspend','hibernate','hybrid-sleep','suspend-then-hibernate','lock'],Systemd::LogindSettings::Ensure],
@@ -2911,14 +2918,17 @@ Struct[{
     Optional['LidSwitchIgnoreInhibited']     => Variant[Enum['yes','no'],Systemd::LogindSettings::Ensure],
     Optional['NAutoVTs']                     => Variant[Integer,Systemd::LogindSettings::Ensure],
     Optional['PowerKeyIgnoreInhibited']      => Variant[Enum['yes','no'],Systemd::LogindSettings::Ensure],
+    Optional['RebootKeyIgnoreInhibited']     => Variant[Enum['yes','no'],Systemd::LogindSettings::Ensure],
     Optional['RemoveIPC']                    => Variant[Enum['yes','no'],Systemd::LogindSettings::Ensure],
     Optional['ReserveVT']                    => Variant[Integer,Systemd::LogindSettings::Ensure],
-    Optional['RuntimeDirectorySize']         => Variant[Systemd::Unit::AmountOrPercent ,Systemd::LogindSettings::Ensure],
+    Optional['RuntimeDirectoryInodesMax']    => Variant[Systemd::Unit::Amount,Systemd::LogindSettings::Ensure],
+    Optional['RuntimeDirectorySize']         => Variant[Systemd::Unit::AmountOrPercent,Systemd::LogindSettings::Ensure],
     Optional['SessionsMax']                  => Variant[Systemd::Unit::Amount,Systemd::LogindSettings::Ensure],
-    Optional['SuspendKeyIgnoreInhibited']    => Variant[Enum['yes','no'],Systemd::LogindSettings::Ensure],
-    Optional['UserTasksMax']                 => Variant[Systemd::Unit::Amount,Systemd::LogindSettings::Ensure],
+    Optional['SleepOperation']               => Variant[Array[Enum['suspend','hibernate','hybrid-sleep','suspend-then-hibernate']],Systemd::LogindSettings::Ensure],
     Optional['StopIdleSessionSec']           => Variant[Systemd::Unit::Amount,Systemd::LogindSettings::Ensure],
+    Optional['SuspendKeyIgnoreInhibited']    => Variant[Enum['yes','no'],Systemd::LogindSettings::Ensure],
     Optional['UserStopDelaySec']             => Variant[Systemd::Unit::Amount,Systemd::LogindSettings::Ensure],
+    Optional['UserTasksMax']                 => Variant[Systemd::Unit::Amount,Systemd::LogindSettings::Ensure],
   }]
 ```
 

--- a/types/logindsettings.pp
+++ b/types/logindsettings.pp
@@ -2,12 +2,19 @@
 type Systemd::LogindSettings = Struct[
   # lint:ignore:140chars
   {
+    Optional['DesignatedMaintenanceTime']    => Variant[Systemd::Unit::Amount,Systemd::LogindSettings::Ensure],
     Optional['HandleHibernateKey']           => Variant[Enum['ignore','poweroff','reboot','halt','kexec','suspend','hibernate','hybrid-sleep','suspend-then-hibernate','lock'],Systemd::LogindSettings::Ensure],
+    Optional['HandleHibernateKeyLongPress']  => Variant[Enum['ignore','poweroff','reboot','halt','kexec','suspend','hibernate','hybrid-sleep','suspend-then-hibernate','lock'],Systemd::LogindSettings::Ensure],
     Optional['HandleLidSwitch']              => Variant[Enum['ignore','poweroff','reboot','halt','kexec','suspend','hibernate','hybrid-sleep','suspend-then-hibernate','lock'],Systemd::LogindSettings::Ensure],
     Optional['HandleLidSwitchDocked']        => Variant[Enum['ignore','poweroff','reboot','halt','kexec','suspend','hibernate','hybrid-sleep','suspend-then-hibernate','lock'],Systemd::LogindSettings::Ensure],
     Optional['HandleLidSwitchExternalPower'] => Variant[Enum['ignore','poweroff','reboot','halt','kexec','suspend','hibernate','hybrid-sleep','suspend-then-hibernate','lock'],Systemd::LogindSettings::Ensure],
     Optional['HandlePowerKey']               => Variant[Enum['ignore','poweroff','reboot','halt','kexec','suspend','hibernate','hybrid-sleep','suspend-then-hibernate','lock'],Systemd::LogindSettings::Ensure],
+    Optional['HandlePowerKeyLongPress']      => Variant[Enum['ignore','poweroff','reboot','halt','kexec','suspend','hibernate','hybrid-sleep','suspend-then-hibernate','lock'],Systemd::LogindSettings::Ensure],
+    Optional['HandleRebootKey']              => Variant[Enum['ignore','poweroff','reboot','halt','kexec','suspend','hibernate','hybrid-sleep','suspend-then-hibernate','lock'],Systemd::LogindSettings::Ensure],
+    Optional['HandleRebootKeyLongPress']     => Variant[Enum['ignore','poweroff','reboot','halt','kexec','suspend','hibernate','hybrid-sleep','suspend-then-hibernate','lock'],Systemd::LogindSettings::Ensure],
+    Optional['HandleSecureAttentionKey']     => Variant[Enum['ignore','poweroff','reboot','halt','kexec','suspend','hibernate','hybrid-sleep','suspend-then-hibernate','lock'],Systemd::LogindSettings::Ensure],
     Optional['HandleSuspendKey']             => Variant[Enum['ignore','poweroff','reboot','halt','kexec','suspend','hibernate','hybrid-sleep','suspend-then-hibernate','lock'],Systemd::LogindSettings::Ensure],
+    Optional['HandleSuspendKeyLongPress']    => Variant[Enum['ignore','poweroff','reboot','halt','kexec','suspend','hibernate','hybrid-sleep','suspend-then-hibernate','lock'],Systemd::LogindSettings::Ensure],
     Optional['HibernateKeyIgnoreInhibited']  => Variant[Enum['yes','no'],Systemd::LogindSettings::Ensure],
     Optional['HoldoffTimeoutSec']            => Variant[Integer,Systemd::LogindSettings::Ensure],
     Optional['IdleAction']                   => Variant[Enum['ignore','poweroff','reboot','halt','kexec','suspend','hibernate','hybrid-sleep','suspend-then-hibernate','lock'],Systemd::LogindSettings::Ensure],
@@ -20,14 +27,17 @@ type Systemd::LogindSettings = Struct[
     Optional['LidSwitchIgnoreInhibited']     => Variant[Enum['yes','no'],Systemd::LogindSettings::Ensure],
     Optional['NAutoVTs']                     => Variant[Integer,Systemd::LogindSettings::Ensure],
     Optional['PowerKeyIgnoreInhibited']      => Variant[Enum['yes','no'],Systemd::LogindSettings::Ensure],
+    Optional['RebootKeyIgnoreInhibited']     => Variant[Enum['yes','no'],Systemd::LogindSettings::Ensure],
     Optional['RemoveIPC']                    => Variant[Enum['yes','no'],Systemd::LogindSettings::Ensure],
     Optional['ReserveVT']                    => Variant[Integer,Systemd::LogindSettings::Ensure],
-    Optional['RuntimeDirectorySize']         => Variant[Systemd::Unit::AmountOrPercent ,Systemd::LogindSettings::Ensure],
+    Optional['RuntimeDirectoryInodesMax']    => Variant[Systemd::Unit::Amount,Systemd::LogindSettings::Ensure],
+    Optional['RuntimeDirectorySize']         => Variant[Systemd::Unit::AmountOrPercent,Systemd::LogindSettings::Ensure],
     Optional['SessionsMax']                  => Variant[Systemd::Unit::Amount,Systemd::LogindSettings::Ensure],
-    Optional['SuspendKeyIgnoreInhibited']    => Variant[Enum['yes','no'],Systemd::LogindSettings::Ensure],
-    Optional['UserTasksMax']                 => Variant[Systemd::Unit::Amount,Systemd::LogindSettings::Ensure],
+    Optional['SleepOperation']               => Variant[Array[Enum['suspend','hibernate','hybrid-sleep','suspend-then-hibernate']],Systemd::LogindSettings::Ensure],
     Optional['StopIdleSessionSec']           => Variant[Systemd::Unit::Amount,Systemd::LogindSettings::Ensure],
+    Optional['SuspendKeyIgnoreInhibited']    => Variant[Enum['yes','no'],Systemd::LogindSettings::Ensure],
     Optional['UserStopDelaySec']             => Variant[Systemd::Unit::Amount,Systemd::LogindSettings::Ensure],
+    Optional['UserTasksMax']                 => Variant[Systemd::Unit::Amount,Systemd::LogindSettings::Ensure],
   }
   # lint:endignore
 ]


### PR DESCRIPTION
<!--
Thank you for contributing to this project!

- This project has a Contributor Code of Conduct: https://voxpupuli.org/coc/
- Please check that here is no existing issue or PR that addresses your problem.
- Our vulnerabilities reporting process is at https://voxpupuli.org/security/

-->
#### Pull Request (PR) description

Added the following settings:

 * `DesignatedMaintenanceTime`
 * `HandleHibernateKeyLongPress`
 * `HandlePowerKeyLongPress`
 * `HandleRebootKey`
 * `HandleRebootKeyLongPress`
 * `HandleSecureAttentionKey`
 * `HandleSuspendKeyLongPress`
 * `RebootKeyIgnoreInhibited`
 * `RuntimeDirectoryInodesMax`
 * `SleepOperation`
 * `UserTasksMax`

Pulled from the list at https://www.freedesktop.org/software/systemd/man/latest/logind.conf.html

#### This Pull Request (PR) fixes the following issues
<!--
Replace this comment with the list of issues or n/a.
Use format:
Fixes #123
Fixes #124
-->
