### PR TITLE
Allow quadlets to be referenced as units

### DIFF
--- a/REFERENCE.md
+++ b/REFERENCE.md
@@ -5430,7 +5430,7 @@ custom datatype that validates different filenames for systemd units and unit te
 * **See also**
   * https://www.freedesktop.org/software/systemd/man/systemd.unit.html
 
-Alias of `Pattern[/^[a-zA-Z0-9:\-_.\\@%]+\.(service|socket|device|mount|automount|swap|target|path|timer|slice|scope)$/]`
+Alias of `Pattern[/^[a-zA-Z0-9:\-_.\\@%]+\.(service|socket|device|mount|automount|swap|target|path|timer|slice|scope|volume|pod|kube|container)$/]`
 
 ### <a name="Systemd--Unit--Amount"></a>`Systemd::Unit::Amount`
 

--- a/types/unit.pp
+++ b/types/unit.pp
@@ -1,3 +1,3 @@
 # @summary custom datatype that validates different filenames for systemd units and unit templates
 # @see https://www.freedesktop.org/software/systemd/man/systemd.unit.html
-type Systemd::Unit = Pattern[/^[a-zA-Z0-9:\-_.\\@%]+\.(service|socket|device|mount|automount|swap|target|path|timer|slice|scope)$/]
+type Systemd::Unit = Pattern[/^[a-zA-Z0-9:\-_.\\@%]+\.(service|socket|device|mount|automount|swap|target|path|timer|slice|scope|volume|pod|kube|container)$/]


### PR DESCRIPTION
#### Pull Request (PR) description

This PR allows quadlets to be referenced as units. 
As the puppet-quadlet uses systemd::unit to validate the entry , it think that is an interesting feature.
Reference here.
 
https://github.com/voxpupuli/puppet-quadlets/blob/master/REFERENCE.md#unit_entry

HOWEVER, i understand that systemd  module should not bear this burden, I would be more than happy to implement alternative solutions. 

#### This Pull Request (PR) is indirectly related to #540
