### PR TITLE
networkd: fix broken implementation and add netdev and link file to spec tests

### DIFF
--- a/REFERENCE.md
+++ b/REFERENCE.md
@@ -1950,7 +1950,6 @@ $_interface => {
 }
 
 systemd::networkd::interface { 'static-enp2s0':
-  type            => 'network',
   interface       => $_interface,
   network_profile => $_network_profile,
 }
@@ -1963,6 +1962,33 @@ with content:
 
   [Match]
   Name=enp2s0
+```
+
+##### 
+
+```puppet
+$_interface => {
+  'filename' => '40-dummy',
+  'netdev' => {
+    'NetDev' => {
+      'Name' => 'dummy0',
+      'Kind' => 'dummy',
+    },
+  'network' => {
+    'Match' => {
+      'Name' => 'dummy0',
+    },
+    'Network' => {
+      'Address' => '2001:DB8::42:42/64
+    },
+  },
+}
+systemd::networkd::interface { 'static-dummy':
+  interface       => $_interface,
+}
+
+Creates a dummy interface, on the file system, two files
+are created therfore.
 ```
 
 #### Parameters
@@ -1978,9 +2004,12 @@ The following parameters are available in the `systemd::networkd::interface` def
 
 ##### <a name="-systemd--networkd--interface--type"></a>`type`
 
-Data type: `Enum['link', 'netdev', 'network']`
+Data type: `Optional[Enum['link', 'netdev', 'network']]`
 
+Parameter is deprecated in favor of the structured $interface parameter
 The type of networkd interface to create
+
+Default value: `undef`
 
 ##### <a name="-systemd--networkd--interface--interface"></a>`interface`
 

--- a/REFERENCE.md
+++ b/REFERENCE.md
@@ -1988,7 +1988,7 @@ systemd::networkd::interface { 'static-dummy':
 }
 
 Creates a dummy interface, on the file system, two files
-are created therfore.
+are created therefore.
 ```
 
 #### Parameters

--- a/manifests/networkd.pp
+++ b/manifests/networkd.pp
@@ -79,29 +79,12 @@ class systemd::networkd (
 
   $interfaces.each | String[1] $interface_name, Systemd::Interface $interface | {
     $_filename=pick($interface['filename'], $interface_name)
-    if 'link' in $interface.keys() {
-      systemd::networkd::interface { $_filename:
-        type            => 'link',
-        path            => $path,
-        interface       => $interface,
-        network_profile => pick($link_profiles[$interface_name], {}),
-      }
-    }
-    if 'netdev' in $interface.keys() {
-      systemd::networkd::interface { $_filename:
-        type            => 'netdev',
-        path            => $path,
-        interface       => $interface,
-        network_profile => pick($netdev_profiles[$interface_name], {}),
-      }
-    }
-    if 'network' in $interface.keys() {
-      systemd::networkd::interface { $_filename:
-        type            => 'network',
-        path            => $path,
-        interface       => $interface,
-        network_profile => pick($network_profiles[$interface_name], {}),
-      }
+    systemd::networkd::interface { $_filename:
+      path            => $path,
+      interface       => $interface,
+      link_profile    => pick($link_profiles[$interface_name], {}),
+      netdev_profile  => pick($netdev_profiles[$interface_name], {}),
+      network_profile => pick($network_profiles[$interface_name], {}),
     }
   }
 }

--- a/manifests/networkd/interface.pp
+++ b/manifests/networkd/interface.pp
@@ -86,7 +86,7 @@
 #   }
 #
 #   Creates a dummy interface, on the file system, two files
-#   are created therfore.
+#   are created therefore.
 # 
 define systemd::networkd::interface (
   Systemd::Interface $interface,

--- a/spec/classes/networkd_spec.rb
+++ b/spec/classes/networkd_spec.rb
@@ -41,6 +41,18 @@ describe 'systemd::networkd' do
         is_expected.to contain_file('/etc/systemd/network/50-static.network').
           with_content(interface_file)
       }
+
+      it {
+        is_expected.to contain_file('/etc/systemd/network/50-vrf.network')
+      }
+
+      it {
+        is_expected.to contain_file('/etc/systemd/network/50-vrf.netdev')
+      }
+
+      it {
+        is_expected.to contain_file('/etc/systemd/network/50-vrf.link')
+      }
     end
   end
 end

--- a/spec/data/rspec.yaml
+++ b/spec/data/rspec.yaml
@@ -12,3 +12,20 @@ systemd::networkd::interfaces:
         Name: enp2s0
       Network:
         Address: 192.168.0.15/24
+  a-vrf:
+    filename: 50-vrf
+    network:
+      Match:
+        Name: vrf
+      Network:
+        Address: 192.168.42.15/32
+    netdev:
+      NetDev:
+        Name: vrf
+        Kind: vrf
+      VRF:
+        Table: 42
+    link:
+      Match:
+        Name: vrf
+    

--- a/spec/defines/networkd/interface_spec.rb
+++ b/spec/defines/networkd/interface_spec.rb
@@ -14,7 +14,6 @@ describe 'systemd::networkd::interface' do
         # This should match the example in the class documentation / readme
         let(:params) do
           {
-            type: 'network',
             interface: {
               filename: '50-static',
               network: {

--- a/spec/defines/networkd/interface_spec.rb
+++ b/spec/defines/networkd/interface_spec.rb
@@ -3,59 +3,119 @@
 require 'spec_helper'
 
 describe 'systemd::networkd::interface' do
+  shared_examples 'systemd::networkd::interface example' do
+    let(:pre_condition) { 'include systemd' }
+    it { is_expected.to compile.with_all_deps }
+
+    it {
+      if params[:interface].key?(:network)
+        is_expected.to contain_file("/etc/systemd/network/#{params[:interface][:filename]}.network")
+      else
+        is_expected.not_to contain_file("/etc/systemd/network/#{params[:interface][:filename]}.network")
+      end
+    }
+
+    it {
+      if params[:interface].key?(:netdev)
+        is_expected.to contain_file("/etc/systemd/network/#{params[:interface][:filename]}.netdev")
+      else
+        is_expected.not_to contain_file("/etc/systemd/network/#{params[:interface][:filename]}.netdev")
+      end
+    }
+
+    it {
+      if params[:interface].key?(:link)
+        is_expected.to contain_file("/etc/systemd/network/#{params[:interface][:filename]}.link")
+      else
+        is_expected.not_to contain_file("/etc/systemd/network/#{params[:interface][:filename]}.link")
+      end
+    }
+  end
+
   context 'supported operating systems' do
     on_supported_os.each do |os, facts|
       context "on #{os}" do
         let(:facts) { facts }
 
-        let(:pre_condition) { 'include systemd' }
         let(:title) { 'static-enp2s0' }
 
-        # This should match the example in the class documentation / readme
-        let(:params) do
-          {
-            interface: {
-              filename: '50-static',
-              network: {
-                Match: {
-                  Name: 'enp2s0',
+        context 'network with a profile' do
+          # This should match the example in the class documentation / readme
+          let(:params) do
+            {
+              interface: {
+                filename: '51-static',
+                network: {
+                  Match: {
+                    Name: 'enp2s0',
+                  },
+                  Network: {
+                    Address: '192.168.0.15/24',
+                  },
                 },
+              },
+              network_profile: {
                 Network: {
-                  Address: '192.168.0.15/24',
+                  Gateway: '192.168.0.1',
                 },
-              },
-            },
-            network_profile: {
-              Network: {
-                Gateway: '192.168.0.1',
-              },
+              }
             }
+          end
+
+          let(:interface_file) do
+            <<~EOT
+              #
+              # This file is managed with puppet
+              #
+              # File name: 51-static.network
+              #
+
+              [Network]
+              Gateway=192.168.0.1
+              Address=192.168.0.15/24
+
+              [Match]
+              Name=enp2s0
+            EOT
+          end
+
+          it_behaves_like 'systemd::networkd::interface example'
+
+          it {
+            is_expected.to contain_file('/etc/systemd/network/51-static.network').
+              with_content(interface_file)
           }
         end
 
-        let(:interface_file) do
-          <<~EOT
-            #
-            # This file is managed with puppet
-            #
-            # File name: 50-static.network
-            #
+        context 'network vrf interface' do
+          let(:title) { 'vrf' }
+          let(:params) do
+            {
+              interface: {
+                filename: '50-vrf',
+                network: {
+                  Match: {
+                    Name: 'vrf',
+                  },
+                  Network: {
+                    Address: '192.168.24.15/24',
+                  },
+                },
+                netdev: {
+                  NetDev: {
+                    Name: 'vrf',
+                    Kind: 'vrf',
+                  },
+                  VRF: {
+                    Table: 42,
+                  },
+                }
+              }
+            }
+          end
 
-            [Network]
-            Gateway=192.168.0.1
-            Address=192.168.0.15/24
-
-            [Match]
-            Name=enp2s0
-          EOT
+          it_behaves_like 'systemd::networkd::interface example'
         end
-
-        it { is_expected.to compile.with_all_deps }
-
-        it {
-          is_expected.to contain_file('/etc/systemd/network/50-static.network').
-            with_content(interface_file)
-        }
       end
     end
   end


### PR DESCRIPTION
This PR contains 3 releated commits which probably should be reviewed separately:

- the first add spec tests to detect #560 issue.
- the scond commit fixes #560 by reworking the interaction inbetween systemd::networkd and systemd::networkd::interface which also:
     - deprectates the type parameter in systemd::networkd::interface
      since this is a duplicate information not needed.
    - introduces the possibility to use one call of the
      systemd::networkd::interface resource to generate link/netdev and
      network file.
- the third one adds some additional spec tests for networkd

fixes: #560 
