### PR TITLE
network type: add missing Domains setting in Network section of netwo…

### DIFF
--- a/REFERENCE.md
+++ b/REFERENCE.md
@@ -4865,6 +4865,7 @@ Struct[{
     'Address'                            => Optional[Variant[Array[String[1]], String[1]]],
     'Gateway'                            => Optional[Variant[Array[String[1]], String[1]]],
     'DNS'                                => Optional[Variant[Array[String[1]], String[1]]],
+    'Domains'                            => Optional[String[1]],
     'UseDomains'                         => Optional[Enum['yes', 'no', 'route']],
     'DNSDefaultRoute'                    => Optional[Enum['yes', 'no']],
     'NTP'                                => Optional[Enum['yes', 'no', 'route']],

--- a/types/interface/network/network.pp
+++ b/types/interface/network/network.pp
@@ -23,6 +23,7 @@ type Systemd::Interface::Network::Network = Struct[{
     'Address'                            => Optional[Variant[Array[String[1]], String[1]]],
     'Gateway'                            => Optional[Variant[Array[String[1]], String[1]]],
     'DNS'                                => Optional[Variant[Array[String[1]], String[1]]],
+    'Domains'                            => Optional[String[1]],
     'UseDomains'                         => Optional[Enum['yes', 'no', 'route']],
     'DNSDefaultRoute'                    => Optional[Enum['yes', 'no']],
     'NTP'                                => Optional[Enum['yes', 'no', 'route']],


### PR DESCRIPTION
network type: add missing Domains setting in Network section of network file
 
see: https://www.freedesktop.org/software/systemd/man/latest/systemd.network.html#Domains=
