### PR TITLE
Manage value of SYSTEMD_RESOLVED_SYNTHESIZE_HOSTNAME

### DIFF
--- a/REFERENCE.md
+++ b/REFERENCE.md
@@ -205,6 +205,7 @@ The following parameters are available in the `systemd` class:
 * [`resolved_ensure`](#-systemd--resolved_ensure)
 * [`resolved_package`](#-systemd--resolved_package)
 * [`resolved_libraries`](#-systemd--resolved_libraries)
+* [`resolved_synthesize_hostname`](#-systemd--resolved_synthesize_hostname)
 * [`manage_nspawn`](#-systemd--manage_nspawn)
 * [`nspawn_package`](#-systemd--nspawn_package)
 * [`dns`](#-systemd--dns)
@@ -350,6 +351,14 @@ Data type: `Array[String[1]]`
 List of library packages needed for systemd-resolved.
 
 Default value: `[]`
+
+##### <a name="-systemd--resolved_synthesize_hostname"></a>`resolved_synthesize_hostname`
+
+Data type: `Optional[Boolean]`
+
+Control if the hostname lookup via systemd should be synthesized.
+
+Default value: `undef`
 
 ##### <a name="-systemd--manage_nspawn"></a>`manage_nspawn`
 

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -34,6 +34,9 @@
 # @param resolved_libraries
 #   List of library packages needed for systemd-resolved.
 #
+# @param resolved_synthesize_hostname
+#   Control if the hostname lookup via systemd should be synthesized.
+#
 # @param manage_nspawn
 #   Manage the systemd-nspawn@service and machinectl subsystem.
 #
@@ -265,6 +268,7 @@ class systemd (
   Optional[Enum['systemd-resolved']]                  $resolved_package = undef,
   Array[String[1]]                                    $resolved_libraries = [],
   Enum['stopped','running']                           $resolved_ensure = 'running',
+  Optional[Boolean]                                   $resolved_synthesize_hostname = undef,
   Optional[Variant[Array[String],String]]             $dns = undef,
   Optional[Variant[Array[String],String]]             $fallback_dns = undef,
   Optional[Variant[Array[String],String]]             $domains = undef,


### PR DESCRIPTION
#### Pull Request (PR) description
systemd version >= v258 (e.g EL10) now synthesizes the resolution of the local hostname by default.

Under certain circumstances it is useful to disable this feature.

Setting the parameter `resolved_synthesize_hostname` to `false`||`true` will disable||enable localhost hostname synthesis.

https://github.com/systemd/systemd/blob/f784a63cfad6a5425af2ebc02a1f9effec4fd079/docs/ENVIRONMENT.md?plain=1#L388C5-L388C41