### PR TITLE
Rewrite `loginctl_user` provider

### DIFF
--- a/lib/puppet/provider/loginctl_user/ruby.rb
+++ b/lib/puppet/provider/loginctl_user/ruby.rb
@@ -12,7 +12,11 @@ Puppet::Type.type(:loginctl_user).provide(:ruby) do
     # loginctl is only successful if the user has an active session (so either logged in or lingering
     # so if loginctl fails, linger is definitly disabled, for users with an active session
     # (eg. logged in or running a timer or ...), the Linger property displays if lingering is activated.
-    :enabled if loginctl('show-user', resource[:name], '--property=Linger', '--value').chomp == 'yes'
+    if loginctl('show-user', resource[:name], '--property=Linger', '--value').chomp == 'yes'
+      :enabled
+    else
+      :disabled
+    end
   rescue Puppet::ExecutionFailure
     :disabled
   end

--- a/spec/unit/puppet/provider/loginctl_user/ruby_spec.rb
+++ b/spec/unit/puppet/provider/loginctl_user/ruby_spec.rb
@@ -13,20 +13,6 @@ describe provider_class do
     }
   end
 
-  context 'when listing instances' do
-    it 'finds all entries' do
-      allow(provider_class).to receive(:loginctl)
-        .with('list-users', '--no-legend')
-        .and_return("0 root\n42 foo\n314 bar\n")
-      allow(provider_class).to receive(:loginctl)
-        .with('show-user', '-p', 'Name', '-p', 'Linger', 'root', 'foo', 'bar')
-        .and_return("Name=root\nLinger=no\n\nName=foo\nLinger=yes\n\nName=bar\nLinger=no\n")
-      inst = provider_class.instances.map!
-
-      expect(inst.size).to eq(3)
-    end
-  end
-
   it 'enables linger' do
     resource = Puppet::Type.type(:loginctl_user).new(common_params)
     expect(provider_class).to receive(:loginctl).with('enable-linger', 'foo')


### PR DESCRIPTION
The current provider uses two steps in the self.instances routine:
1. Fetch all users currently logged in with the command `loginctl list-users`. Result is a list of all users with an open session (so this includes user which are lingering, users that are logged in etc.).
2. For each found user the command `loginctl show-user` is executed to get the current state of the 'Linger' setting.

The second command also fails for users not logged in. Since the first command only lists logged in users, the failure is a quite seldom event (also described in #302 ).

A user with disabled linger is 'usually' (at least I'm not logged in on all machines running puppet ;)) not logged in, so it does not appear on the first command. Therefore it's linger status is not checked. This results in running loginctl to disable the setting on each puppet run (described in #301 ).

The approach I took in this MR is to get the Linger status in a single step and handle the failure in case the user is not logged in. If the user is logged in, we an use the Linger state to decide if lingering is activated or not. In the case the user is not logged in, it's for sure not lingering (since these are listed). So setting the is value to disabled should be correct.

Fixes: #302
Fixes: #301 
 