### PR TITLE
`Systemd::Unit::Unit`: Allow `infinity` for `StartLimitBurst`

### DIFF
--- a/REFERENCE.md
+++ b/REFERENCE.md
@@ -6463,7 +6463,7 @@ Struct[{
     Optional['ConditionFileNotEmpty']       => Variant[Enum[''],Stdlib::Unixpath,Pattern[/^!.*$/],Array[Variant[Enum[''],Stdlib::Unixpath,Pattern[/^!.*$/]],1]],
     Optional['ConditionFileIsExecutable']   => Variant[Enum[''],Stdlib::Unixpath,Pattern[/^!.*$/],Array[Variant[Enum[''],Stdlib::Unixpath,Pattern[/^!.*$/]],1]],
     Optional['StartLimitIntervalSec']       => String[1],
-    Optional['StartLimitBurst']             => Integer[1],
+    Optional['StartLimitBurst']             => Variant[Enum['infinity'],Integer[1]],
   }]
 ```
 

--- a/types/unit/unit.pp
+++ b/types/unit/unit.pp
@@ -50,6 +50,6 @@ type Systemd::Unit::Unit = Struct[
     Optional['ConditionFileNotEmpty']       => Variant[Enum[''],Stdlib::Unixpath,Pattern[/^!.*$/],Array[Variant[Enum[''],Stdlib::Unixpath,Pattern[/^!.*$/]],1]],
     Optional['ConditionFileIsExecutable']   => Variant[Enum[''],Stdlib::Unixpath,Pattern[/^!.*$/],Array[Variant[Enum[''],Stdlib::Unixpath,Pattern[/^!.*$/]],1]],
     Optional['StartLimitIntervalSec']       => String[1],
-    Optional['StartLimitBurst']             => Integer[1],
+    Optional['StartLimitBurst']             => Variant[Enum['infinity'],Integer[1]],
   }
 ]


### PR DESCRIPTION
#### Pull Request (PR) description
Allow infinity for StartLimitBurst
#### This Pull Request (PR) fixes the following issues
Fixes #609 
