### PR TITLE
Add support for new machine-info metadata

### DIFF
--- a/REFERENCE.md
+++ b/REFERENCE.md
@@ -5772,6 +5772,7 @@ Struct[{
     Optional['LOCATION']        => String[1],
     Optional['HARDWARE_VENDOR'] => String[1],
     Optional['HARDWARE_MODEL']  => String[1],
+    Optional['TAGS']            => String[1],
   }]
 ```
 

--- a/REFERENCE.md
+++ b/REFERENCE.md
@@ -5765,14 +5765,16 @@ Alias of
 
 ```puppet
 Struct[{
-    Optional['PRETTY_HOSTNAME'] => String[1],
-    Optional['ICON_NAME']       => String[1],
-    Optional['CHASSIS']         => String[1],
-    Optional['DEPLOYMENT']      => String[1],
-    Optional['LOCATION']        => String[1],
-    Optional['HARDWARE_VENDOR'] => String[1],
-    Optional['HARDWARE_MODEL']  => String[1],
-    Optional['TAGS']            => String[1],
+    Optional['PRETTY_HOSTNAME']  => String[1],
+    Optional['ICON_NAME']        => String[1],
+    Optional['CHASSIS']          => String[1],
+    Optional['DEPLOYMENT']       => String[1],
+    Optional['LOCATION']         => String[1],
+    Optional['HARDWARE_MODEL']   => String[1],
+    Optional['HARDWARE_SKU']     => String[1],
+    Optional['HARDWARE_VENDOR']  => String[1],
+    Optional['HARDWARE_VERSION'] => String[1],
+    Optional['TAGS']             => String[1],
   }]
 ```
 

--- a/spec/type_aliases/systemd_machineinfosettings_spec.rb
+++ b/spec/type_aliases/systemd_machineinfosettings_spec.rb
@@ -10,6 +10,8 @@ describe 'Systemd::MachineInfoSettings' do
   it { is_expected.to allow_value({ 'LOCATION' => 'Home' }) }
   it { is_expected.to allow_value({ 'HARDWARE_VENDOR' => 'fake vendor' }) }
   it { is_expected.to allow_value({ 'HARDWARE_MODEL' => 'fake model' }) }
+  it { is_expected.to allow_value({ 'TAGS' => 'sometag' }) }
+  it { is_expected.to allow_value({ 'TAGS' => 'some:tag' }) }
 
   it { is_expected.not_to allow_value({ 'PRETTY_HOSTNAME' => '' }) }
 end

--- a/spec/type_aliases/systemd_machineinfosettings_spec.rb
+++ b/spec/type_aliases/systemd_machineinfosettings_spec.rb
@@ -8,8 +8,10 @@ describe 'Systemd::MachineInfoSettings' do
   it { is_expected.to allow_value({ 'CHASSIS' => 'server' }) }
   it { is_expected.to allow_value({ 'DEPLOYMENT' => 'production' }) }
   it { is_expected.to allow_value({ 'LOCATION' => 'Home' }) }
-  it { is_expected.to allow_value({ 'HARDWARE_VENDOR' => 'fake vendor' }) }
   it { is_expected.to allow_value({ 'HARDWARE_MODEL' => 'fake model' }) }
+  it { is_expected.to allow_value({ 'HARDWARE_SKU' => 'fake sku' }) }
+  it { is_expected.to allow_value({ 'HARDWARE_VENDOR' => 'fake vendor' }) }
+  it { is_expected.to allow_value({ 'HARDWARE_VERSION' => 'fake version' }) }
   it { is_expected.to allow_value({ 'TAGS' => 'sometag' }) }
   it { is_expected.to allow_value({ 'TAGS' => 'some:tag' }) }
 

--- a/types/machineinfosettings.pp
+++ b/types/machineinfosettings.pp
@@ -1,13 +1,15 @@
 # Matches Systemd machine-info (hostnamectl) file Struct
 type Systemd::MachineInfoSettings = Struct[
   {
-    Optional['PRETTY_HOSTNAME'] => String[1],
-    Optional['ICON_NAME']       => String[1],
-    Optional['CHASSIS']         => String[1],
-    Optional['DEPLOYMENT']      => String[1],
-    Optional['LOCATION']        => String[1],
-    Optional['HARDWARE_VENDOR'] => String[1],
-    Optional['HARDWARE_MODEL']  => String[1],
-    Optional['TAGS']            => String[1],
+    Optional['PRETTY_HOSTNAME']  => String[1],
+    Optional['ICON_NAME']        => String[1],
+    Optional['CHASSIS']          => String[1],
+    Optional['DEPLOYMENT']       => String[1],
+    Optional['LOCATION']         => String[1],
+    Optional['HARDWARE_MODEL']   => String[1],
+    Optional['HARDWARE_SKU']     => String[1],
+    Optional['HARDWARE_VENDOR']  => String[1],
+    Optional['HARDWARE_VERSION'] => String[1],
+    Optional['TAGS']             => String[1],
   }
 ]

--- a/types/machineinfosettings.pp
+++ b/types/machineinfosettings.pp
@@ -8,5 +8,6 @@ type Systemd::MachineInfoSettings = Struct[
     Optional['LOCATION']        => String[1],
     Optional['HARDWARE_VENDOR'] => String[1],
     Optional['HARDWARE_MODEL']  => String[1],
+    Optional['TAGS']            => String[1],
   }
 ]


### PR DESCRIPTION
<!--
Thank you for contributing to this project!

- This project has a Contributor Code of Conduct: https://voxpupuli.org/coc/
- Please check that here is no existing issue or PR that addresses your problem.
- Our vulnerabilities reporting process is at https://voxpupuli.org/security/

-->
#### Pull Request (PR) description
Add support for newly defined `TAGS` metadata for machine-info

#### This Pull Request (PR) fixes the following issues
<!--
Replace this comment with the list of issues or n/a.
Use format:
Fixes #123
Fixes #124
-->
