### PR TITLE
feat: use config drop-in for journald settings

### DIFF
--- a/manifests/journald.pp
+++ b/manifests/journald.pp
@@ -7,10 +7,18 @@ class systemd::journald {
   service { 'systemd-journald':
     ensure => running,
   }
+  if !empty($systemd::journald_settings) {
+    file { '/etc/systemd/journald.conf.d':
+      ensure => directory,
+      owner  => 'root',
+      group  => 'root',
+      mode   => '0755',
+    }
+  }
   $systemd::journald_settings.each |$option, $value| {
     ini_setting {
       $option:
-        path    => '/etc/systemd/journald.conf',
+        path    => '/etc/systemd/journald.conf.d/puppet.conf',
         section => 'Journal',
         setting => $option,
         notify  => Service['systemd-journald'],

--- a/spec/classes/init_spec.rb
+++ b/spec/classes/init_spec.rb
@@ -771,23 +771,29 @@ describe 'systemd' do
             )
 
             is_expected.to have_ini_setting_resource_count(3)
+            is_expected.to contain_file('/etc/systemd/journald.conf.d').with(
+              ensure: 'directory',
+              owner: 'root',
+              group: 'root',
+              mode: '0755',
+            )
 
             expect(subject).to contain_ini_setting('Storage').with(
-              path: '/etc/systemd/journald.conf',
+              path: '/etc/systemd/journald.conf.d/puppet.conf',
               section: 'Journal',
               notify: 'Service[systemd-journald]',
               value: 'auto',
             )
 
             expect(subject).to contain_ini_setting('MaxRetentionSec').with(
-              path: '/etc/systemd/journald.conf',
+              path: '/etc/systemd/journald.conf.d/puppet.conf',
               section: 'Journal',
               notify: 'Service[systemd-journald]',
               value: '5day',
             )
 
             expect(subject).to contain_ini_setting('MaxLevelStore').with(
-              path: '/etc/systemd/journald.conf',
+              path: '/etc/systemd/journald.conf.d/puppet.conf',
               section: 'Journal',
               notify: 'Service[systemd-journald]',
               ensure: 'absent',


### PR DESCRIPTION
use a file in /etc/systemd/journald.conf.d/ instead of modifying the main journald config file. Debian ships a /usr/lib/systemd/journald.conf.d/syslog.conf setting ForwardToSyslog=yes which can not be overridden by the main config file, so we need to use a drop-in.

