### PR TITLE
feat(machine-info): Permit unset machine-info vars

### DIFF
--- a/REFERENCE.md
+++ b/REFERENCE.md
@@ -5880,16 +5880,16 @@ Alias of
 
 ```puppet
 Struct[{
-    Optional['PRETTY_HOSTNAME']  => String[1],
-    Optional['ICON_NAME']        => String[1],
-    Optional['CHASSIS']          => String[1],
-    Optional['DEPLOYMENT']       => String[1],
-    Optional['LOCATION']         => String[1],
-    Optional['HARDWARE_MODEL']   => String[1],
-    Optional['HARDWARE_SKU']     => String[1],
-    Optional['HARDWARE_VENDOR']  => String[1],
-    Optional['HARDWARE_VERSION'] => String[1],
-    Optional['TAGS']             => String[1],
+    Optional['PRETTY_HOSTNAME']  => String,
+    Optional['ICON_NAME']        => String,
+    Optional['CHASSIS']          => String,
+    Optional['DEPLOYMENT']       => String,
+    Optional['LOCATION']         => String,
+    Optional['HARDWARE_MODEL']   => String,
+    Optional['HARDWARE_SKU']     => String,
+    Optional['HARDWARE_VENDOR']  => String,
+    Optional['HARDWARE_VERSION'] => String,
+    Optional['TAGS']             => String,
   }]
 ```
 

--- a/spec/type_aliases/systemd_machineinfosettings_spec.rb
+++ b/spec/type_aliases/systemd_machineinfosettings_spec.rb
@@ -3,17 +3,25 @@
 require 'spec_helper'
 
 describe 'Systemd::MachineInfoSettings' do
+  it { is_expected.to allow_value({ 'PRETTY_HOSTNAME' => '' }) }
   it { is_expected.to allow_value({ 'PRETTY_HOSTNAME' => 'example' }) }
+  it { is_expected.to allow_value({ 'ICON_NAME' => '' }) }
   it { is_expected.to allow_value({ 'ICON_NAME' => 'computer' }) }
+  it { is_expected.to allow_value({ 'CHASSIS' => '' }) }
   it { is_expected.to allow_value({ 'CHASSIS' => 'server' }) }
+  it { is_expected.to allow_value({ 'DEPLOYMENT' => '' }) }
   it { is_expected.to allow_value({ 'DEPLOYMENT' => 'production' }) }
+  it { is_expected.to allow_value({ 'LOCATION' => '' }) }
   it { is_expected.to allow_value({ 'LOCATION' => 'Home' }) }
+  it { is_expected.to allow_value({ 'HARDWARE_MODEL' => '' }) }
   it { is_expected.to allow_value({ 'HARDWARE_MODEL' => 'fake model' }) }
+  it { is_expected.to allow_value({ 'HARDWARE_SKU' => '' }) }
   it { is_expected.to allow_value({ 'HARDWARE_SKU' => 'fake sku' }) }
+  it { is_expected.to allow_value({ 'HARDWARE_VENDOR' => '' }) }
   it { is_expected.to allow_value({ 'HARDWARE_VENDOR' => 'fake vendor' }) }
+  it { is_expected.to allow_value({ 'HARDWARE_VERSION' => '' }) }
   it { is_expected.to allow_value({ 'HARDWARE_VERSION' => 'fake version' }) }
+  it { is_expected.to allow_value({ 'TAGS' => '' }) }
   it { is_expected.to allow_value({ 'TAGS' => 'sometag' }) }
   it { is_expected.to allow_value({ 'TAGS' => 'some:tag' }) }
-
-  it { is_expected.not_to allow_value({ 'PRETTY_HOSTNAME' => '' }) }
 end

--- a/types/machineinfosettings.pp
+++ b/types/machineinfosettings.pp
@@ -1,15 +1,15 @@
 # Matches Systemd machine-info (hostnamectl) file Struct
 type Systemd::MachineInfoSettings = Struct[
   {
-    Optional['PRETTY_HOSTNAME']  => String[1],
-    Optional['ICON_NAME']        => String[1],
-    Optional['CHASSIS']          => String[1],
-    Optional['DEPLOYMENT']       => String[1],
-    Optional['LOCATION']         => String[1],
-    Optional['HARDWARE_MODEL']   => String[1],
-    Optional['HARDWARE_SKU']     => String[1],
-    Optional['HARDWARE_VENDOR']  => String[1],
-    Optional['HARDWARE_VERSION'] => String[1],
-    Optional['TAGS']             => String[1],
+    Optional['PRETTY_HOSTNAME']  => String,
+    Optional['ICON_NAME']        => String,
+    Optional['CHASSIS']          => String,
+    Optional['DEPLOYMENT']       => String,
+    Optional['LOCATION']         => String,
+    Optional['HARDWARE_MODEL']   => String,
+    Optional['HARDWARE_SKU']     => String,
+    Optional['HARDWARE_VENDOR']  => String,
+    Optional['HARDWARE_VERSION'] => String,
+    Optional['TAGS']             => String,
   }
 ]


### PR DESCRIPTION
#### Pull Request (PR) description

systemd supports unsetting vars within machine-info. When `=''` the default will be used. Often this is simply unset or determined from the host hardware.

One of my on site users decided to stop setting some of these machine-info vars and noted the incompatibility.