### PR TITLE
Allow masking a service unit without any `service_entry`

### DIFF
--- a/manifests/manage_unit.pp
+++ b/manifests/manage_unit.pp
@@ -211,7 +211,9 @@ define systemd::manage_unit (
     fail("Systemd::Manage_unit[${name}]: swap_entry is only valid for swap units")
   }
 
-  if $ensure != 'absent' and  $name =~ Pattern['^[^/]+\.service'] and !$service_entry {
+  # When enable='mask', units are symlinked to /dev/null, making type-specific
+  # entry parameters (service_entry, timer_entry, etc) unnecessary and can be omitted
+  if $ensure != 'absent' and $enable != 'mask' and $name =~ Pattern['^[^/]+\.service'] and !$service_entry {
     fail("Systemd::Manage_unit[${name}]: service_entry is required for service units")
   }
 

--- a/spec/defines/manage_unit_spec.rb
+++ b/spec/defines/manage_unit_spec.rb
@@ -185,6 +185,139 @@ describe 'systemd::manage_unit' do
           }
         end
 
+        context 'when masking a service unit without service_entry' do
+          let(:title) { 'masked.service' }
+
+          let(:params) do
+            {
+              enable: 'mask',
+            }
+          end
+
+          it { is_expected.to compile.with_all_deps }
+
+          it {
+            is_expected.to contain_file('/etc/systemd/system/masked.service').with(
+              ensure: 'link',
+              target: '/dev/null',
+            )
+          }
+        end
+
+        context 'when masking a timer unit without timer_entry' do
+          let(:title) { 'masked.timer' }
+
+          let(:params) do
+            {
+              enable: 'mask',
+            }
+          end
+
+          it { is_expected.to compile.with_all_deps }
+
+          it {
+            is_expected.to contain_file('/etc/systemd/system/masked.timer').with(
+              ensure: 'link',
+              target: '/dev/null',
+            )
+          }
+        end
+
+        context 'when masking a socket unit without socket_entry' do
+          let(:title) { 'masked.socket' }
+
+          let(:params) do
+            {
+              enable: 'mask',
+            }
+          end
+
+          it { is_expected.to compile.with_all_deps }
+
+          it {
+            is_expected.to contain_file('/etc/systemd/system/masked.socket').with(
+              ensure: 'link',
+              target: '/dev/null',
+            )
+          }
+        end
+
+        context 'when masking a path unit without path_entry' do
+          let(:title) { 'masked.path' }
+
+          let(:params) do
+            {
+              enable: 'mask',
+            }
+          end
+
+          it { is_expected.to compile.with_all_deps }
+
+          it {
+            is_expected.to contain_file('/etc/systemd/system/masked.path').with(
+              ensure: 'link',
+              target: '/dev/null',
+            )
+          }
+        end
+
+        context 'when masking a slice unit without slice_entry' do
+          let(:title) { 'masked.slice' }
+
+          let(:params) do
+            {
+              enable: 'mask',
+            }
+          end
+
+          it { is_expected.to compile.with_all_deps }
+
+          it {
+            is_expected.to contain_file('/etc/systemd/system/masked.slice').with(
+              ensure: 'link',
+              target: '/dev/null',
+            )
+          }
+        end
+
+        context 'when masking an automount unit without automount_entry' do
+          let(:title) { 'masked.automount' }
+
+          let(:params) do
+            {
+              enable: 'mask',
+            }
+          end
+
+          it { is_expected.to compile.with_all_deps }
+
+          it {
+            is_expected.to contain_file('/etc/systemd/system/masked.automount').with(
+              ensure: 'link',
+              target: '/dev/null',
+            )
+          }
+        end
+
+        context 'when masking a swap unit without swap_entry' do
+          let(:title) { 'masked.swap' }
+
+          let(:params) do
+            {
+              enable: 'mask',
+            }
+          end
+
+          it { is_expected.to compile.with_all_deps }
+
+          it {
+            is_expected.to contain_file('/etc/systemd/system/masked.swap').with(
+              ensure: 'link',
+              target: '/dev/null',
+            )
+          }
+        end
+
         context 'on a swap' do
           let(:title) { 'file.swap' }
 


### PR DESCRIPTION
<!--
Thank you for contributing to this project!

- This project has a Contributor Code of Conduct: https://voxpupuli.org/coc/
- Please check that here is no existing issue or PR that addresses your problem.
- Our vulnerabilities reporting process is at https://voxpupuli.org/security/

-->
#### Pull Request (PR) description
I ran into this oddity trying to mask `rc-local.service` which is automatically generated.

#### This Pull Request (PR) fixes the following issues
<!--
Replace this comment with the list of issues or n/a.
Use format:
Fixes #123
Fixes #124
-->
