### PR TITLE
add dropin_file and manage_dropin defined resources for journald

### DIFF
--- a/REFERENCE.md
+++ b/REFERENCE.md
@@ -38,6 +38,8 @@
 * [`systemd::daemon_reexec`](#systemd--daemon_reexec): Run systemctl daemon-reexec
 * [`systemd::daemon_reload`](#systemd--daemon_reload): Run systemctl daemon-reload
 * [`systemd::dropin_file`](#systemd--dropin_file): Creates a drop-in file for a systemd unit
+* [`systemd::journald::dropin_file`](#systemd--journald--dropin_file): Creates a drop-in file for journald configuration
+* [`systemd::journald::manage_dropin`](#systemd--journald--manage_dropin): Creates a drop-in file for journald configuration from a template
 * [`systemd::manage_dropin`](#systemd--manage_dropin): Creates a drop-in file for a systemd unit from a template
 * [`systemd::manage_unit`](#systemd--manage_unit): Generate unit file from template
 * [`systemd::modules_load`](#systemd--modules_load): Creates a modules-load.d drop file
@@ -264,6 +266,8 @@ The following parameters are available in the `systemd` class:
 * [`set_local_rtc`](#-systemd--set_local_rtc)
 * [`manage_journald`](#-systemd--manage_journald)
 * [`journald_settings`](#-systemd--journald_settings)
+* [`journald_use_etc_conf`](#-systemd--journald_use_etc_conf)
+* [`journald_purge_dropin_dirs`](#-systemd--journald_purge_dropin_dirs)
 * [`manage_journal_upload`](#-systemd--manage_journal_upload)
 * [`journal_upload_settings`](#-systemd--journal_upload_settings)
 * [`manage_journal_remote`](#-systemd--manage_journal_remote)
@@ -770,6 +774,22 @@ Data type: `Systemd::JournaldSettings`
 Config Hash that is used to configure settings in journald.conf
 
 Default value: `{}`
+
+##### <a name="-systemd--journald_use_etc_conf"></a>`journald_use_etc_conf`
+
+Data type: `Boolean`
+
+Whether to use the /etc/systemd/journald.conf file.
+
+Default value: `true`
+
+##### <a name="-systemd--journald_purge_dropin_dirs"></a>`journald_purge_dropin_dirs`
+
+Data type: `Boolean`
+
+Whether to purge the journald dropin directories. This will remove any files in the dropin directories that are not managed by Puppet.
+
+Default value: `false`
 
 ##### <a name="-systemd--manage_journal_upload"></a>`manage_journal_upload`
 
@@ -1457,6 +1477,214 @@ Data type: `Boolean`
 Call systemd::daemon_reload
 
 Default value: `true`
+
+### <a name="systemd--journald--dropin_file"></a>`systemd::journald::dropin_file`
+
+Creates a drop-in file for journald configuration
+
+* **See also**
+  * journald.conf(5)
+
+#### Parameters
+
+The following parameters are available in the `systemd::journald::dropin_file` defined type:
+
+* [`filename`](#-systemd--journald--dropin_file--filename)
+* [`ensure`](#-systemd--journald--dropin_file--ensure)
+* [`path`](#-systemd--journald--dropin_file--path)
+* [`selinux_ignore_defaults`](#-systemd--journald--dropin_file--selinux_ignore_defaults)
+* [`content`](#-systemd--journald--dropin_file--content)
+* [`source`](#-systemd--journald--dropin_file--source)
+* [`owner`](#-systemd--journald--dropin_file--owner)
+* [`group`](#-systemd--journald--dropin_file--group)
+* [`mode`](#-systemd--journald--dropin_file--mode)
+* [`show_diff`](#-systemd--journald--dropin_file--show_diff)
+* [`notify_journald`](#-systemd--journald--dropin_file--notify_journald)
+
+##### <a name="-systemd--journald--dropin_file--filename"></a>`filename`
+
+Data type: `Systemd::Dropin`
+
+The filename of the drop in. The full path is determined using the path and this filename.
+
+Default value: `$name`
+
+##### <a name="-systemd--journald--dropin_file--ensure"></a>`ensure`
+
+Data type: `Enum['present', 'absent', 'file']`
+
+the state of this dropin file
+
+Default value: `'present'`
+
+##### <a name="-systemd--journald--dropin_file--path"></a>`path`
+
+Data type: `Stdlib::Absolutepath`
+
+The journald dropin configuration path
+
+Default value: `'/etc/systemd/journald.conf.d'`
+
+##### <a name="-systemd--journald--dropin_file--selinux_ignore_defaults"></a>`selinux_ignore_defaults`
+
+Data type: `Boolean`
+
+If Puppet should ignore the default SELinux labels.
+
+Default value: `false`
+
+##### <a name="-systemd--journald--dropin_file--content"></a>`content`
+
+Data type: `Optional[Variant[String,Sensitive[String]]]`
+
+The full content of the unit file (Mutually exclusive with `$source`)
+
+Default value: `undef`
+
+##### <a name="-systemd--journald--dropin_file--source"></a>`source`
+
+Data type: `Optional[String]`
+
+The `File` resource compatible `source` (Mutually exclusive with `$content`)
+
+Default value: `undef`
+
+##### <a name="-systemd--journald--dropin_file--owner"></a>`owner`
+
+Data type: `String[1]`
+
+The owner to set on the dropin file
+
+Default value: `'root'`
+
+##### <a name="-systemd--journald--dropin_file--group"></a>`group`
+
+Data type: `String[1]`
+
+The group to set on the dropin file
+
+Default value: `'root'`
+
+##### <a name="-systemd--journald--dropin_file--mode"></a>`mode`
+
+Data type: `Stdlib::Filemode`
+
+The mode to set on the dropin file
+
+Default value: `'0644'`
+
+##### <a name="-systemd--journald--dropin_file--show_diff"></a>`show_diff`
+
+Data type: `Boolean`
+
+Whether to show the diff when updating dropin file
+
+Default value: `true`
+
+##### <a name="-systemd--journald--dropin_file--notify_journald"></a>`notify_journald`
+
+Data type: `Boolean`
+
+Restart the journald service if the dropin file changes
+
+Default value: `true`
+
+### <a name="systemd--journald--manage_dropin"></a>`systemd::journald::manage_dropin`
+
+Creates a drop-in file for journald configuration from a template
+
+#### Parameters
+
+The following parameters are available in the `systemd::journald::manage_dropin` defined type:
+
+* [`filename`](#-systemd--journald--manage_dropin--filename)
+* [`ensure`](#-systemd--journald--manage_dropin--ensure)
+* [`path`](#-systemd--journald--manage_dropin--path)
+* [`selinux_ignore_defaults`](#-systemd--journald--manage_dropin--selinux_ignore_defaults)
+* [`owner`](#-systemd--journald--manage_dropin--owner)
+* [`group`](#-systemd--journald--manage_dropin--group)
+* [`mode`](#-systemd--journald--manage_dropin--mode)
+* [`show_diff`](#-systemd--journald--manage_dropin--show_diff)
+* [`notify_journald`](#-systemd--journald--manage_dropin--notify_journald)
+* [`journal_entry`](#-systemd--journald--manage_dropin--journal_entry)
+
+##### <a name="-systemd--journald--manage_dropin--filename"></a>`filename`
+
+Data type: `Systemd::Dropin`
+
+The filename of the drop in. The full path is determined using the path and this filename.
+
+Default value: `$name`
+
+##### <a name="-systemd--journald--manage_dropin--ensure"></a>`ensure`
+
+Data type: `Enum['present', 'absent']`
+
+the state of this dropin file
+
+Default value: `'present'`
+
+##### <a name="-systemd--journald--manage_dropin--path"></a>`path`
+
+Data type: `Optional[Stdlib::Absolutepath]`
+
+The journald dropin configuration path
+
+Default value: `undef`
+
+##### <a name="-systemd--journald--manage_dropin--selinux_ignore_defaults"></a>`selinux_ignore_defaults`
+
+Data type: `Optional[Boolean]`
+
+If Puppet should ignore the default SELinux labels.
+
+Default value: `undef`
+
+##### <a name="-systemd--journald--manage_dropin--owner"></a>`owner`
+
+Data type: `Optional[String[1]]`
+
+The owner to set on the dropin file
+
+Default value: `undef`
+
+##### <a name="-systemd--journald--manage_dropin--group"></a>`group`
+
+Data type: `Optional[String[1]]`
+
+The group to set on the dropin file
+
+Default value: `undef`
+
+##### <a name="-systemd--journald--manage_dropin--mode"></a>`mode`
+
+Data type: `Optional[Stdlib::Filemode]`
+
+The mode to set on the dropin file
+
+Default value: `undef`
+
+##### <a name="-systemd--journald--manage_dropin--show_diff"></a>`show_diff`
+
+Data type: `Optional[Boolean]`
+
+Whether to show the diff when updating dropin file
+
+Default value: `undef`
+
+##### <a name="-systemd--journald--manage_dropin--notify_journald"></a>`notify_journald`
+
+Data type: `Optional[Boolean]`
+
+Restart the journald service if the dropin file changes
+
+Default value: `undef`
+
+##### <a name="-systemd--journald--manage_dropin--journal_entry"></a>`journal_entry`
+
+Data type: `Systemd::JournaldSettings`
+
+key value pairs for the [Journal] section of the dropin file
 
 ### <a name="systemd--manage_dropin"></a>`systemd::manage_dropin`
 

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -192,6 +192,12 @@
 # @param journald_settings
 #   Config Hash that is used to configure settings in journald.conf
 #
+# @param journald_use_etc_conf
+#  Whether to use the /etc/systemd/journald.conf file.
+#
+# @param journald_purge_dropin_dirs
+#  Whether to purge the journald dropin directories. This will remove any files in the dropin directories that are not managed by Puppet.
+#
 # @param manage_journal_upload
 #   Manage the systemd journal upload to a remote server
 #
@@ -383,6 +389,8 @@ class systemd (
   Boolean                                             $purge_dropin_dirs = true,
   Boolean                                             $manage_journald = true,
   Systemd::JournaldSettings                           $journald_settings = {},
+  Boolean                                             $journald_use_etc_conf = true,
+  Boolean                                             $journald_purge_dropin_dirs = false,
   Boolean                                             $manage_journal_upload = false,
   Systemd::JournalUploadSettings                      $journal_upload_settings = {},
   Boolean                                             $manage_journal_remote = false,

--- a/manifests/journald.pp
+++ b/manifests/journald.pp
@@ -1,27 +1,30 @@
 # @api private
 # @summary This class manages and configures journald.
 # @see https://www.freedesktop.org/software/systemd/man/journald.conf.html
-class systemd::journald {
+class systemd::journald (
+) {
   assert_private()
-
+  include systemd
   service { 'systemd-journald':
     ensure => running,
   }
-  $systemd::journald_settings.each |$option, $value| {
-    ini_setting {
-      $option:
-        path    => '/etc/systemd/journald.conf',
-        section => 'Journal',
-        setting => $option,
-        notify  => Service['systemd-journald'],
-    }
-    if $value =~ Hash {
-      Ini_setting[$option] {
-        * => $value,
+  if $systemd::journald_use_etc_conf {
+    $systemd::journald_settings.each |$option, $value| {
+      ini_setting {
+        $option:
+          path    => '/etc/systemd/journald.conf',
+          section => 'Journal',
+          setting => $option,
+          notify  => Service['systemd-journald'],
       }
-    } else {
-      Ini_setting[$option] {
-        value   => $value,
+      if $value =~ Hash {
+        Ini_setting[$option] {
+          * => $value,
+        }
+      } else {
+        Ini_setting[$option] {
+          value => $value,
+        }
       }
     }
   }

--- a/manifests/journald/dropin_file.pp
+++ b/manifests/journald/dropin_file.pp
@@ -1,0 +1,64 @@
+# Creates a drop-in file for journald configuration
+#
+# @api public
+#
+# @see journald.conf(5)
+# @param filename The filename of the drop in. The full path is determined using the path and this filename.
+# @param ensure the state of this dropin file
+# @param path The journald dropin configuration path
+# @param selinux_ignore_defaults If Puppet should ignore the default SELinux labels.
+# @param content The full content of the unit file (Mutually exclusive with `$source`)
+# @param source The `File` resource compatible `source` (Mutually exclusive with `$content`)
+# @param owner The owner to set on the dropin file
+# @param group The group to set on the dropin file
+# @param mode The mode to set on the dropin file
+# @param show_diff Whether to show the diff when updating dropin file
+# @param notify_journald Restart the journald service if the dropin file changes
+define systemd::journald::dropin_file (
+  Systemd::Dropin                             $filename                = $name,
+  Enum['present', 'absent', 'file']           $ensure                  = 'present',
+  Stdlib::Absolutepath                        $path                    = '/etc/systemd/journald.conf.d',
+  Boolean                                     $selinux_ignore_defaults = false,
+  Optional[Variant[String,Sensitive[String]]] $content                 = undef,
+  Optional[String]                            $source                  = undef,
+  String[1]                                   $owner                   = 'root',
+  String[1]                                   $group                   = 'root',
+  Stdlib::Filemode                            $mode                    = '0644',
+  Boolean                                     $show_diff               = true,
+  Boolean                                     $notify_journald         = true,
+) {
+  include systemd
+
+  if $systemd::manage_journald == false {
+    fail('systemd::journald::dropin_file is disabled because systemd::manage_journald is set to false')
+  }
+  $full_filename = "${path}/${filename}"
+
+  if $ensure != 'absent' {
+    ensure_resource('file', $path,
+      {
+        ensure                  => 'directory',
+        owner                   => 'root',
+        group                   => 'root',
+        recurse                 => $systemd::journald_purge_dropin_dirs,
+        purge                   => $systemd::journald_purge_dropin_dirs,
+        selinux_ignore_defaults => $selinux_ignore_defaults,
+      },
+    )
+  }
+
+  file { $full_filename:
+    ensure                  => stdlib::ensure($ensure, 'file'),
+    content                 => $content,
+    source                  => $source,
+    owner                   => $owner,
+    group                   => $group,
+    mode                    => $mode,
+    selinux_ignore_defaults => $selinux_ignore_defaults,
+    show_diff               => $show_diff,
+  }
+
+  if $notify_journald {
+    File[$full_filename] ~> Service['systemd-journald']
+  }
+}

--- a/manifests/journald/manage_dropin.pp
+++ b/manifests/journald/manage_dropin.pp
@@ -1,0 +1,38 @@
+# Creates a drop-in file for journald configuration from a template
+#
+# @api public
+# @param filename The filename of the drop in. The full path is determined using the path and this filename.
+# @param ensure the state of this dropin file
+# @param path The journald dropin configuration path
+# @param selinux_ignore_defaults If Puppet should ignore the default SELinux labels.
+# @param owner The owner to set on the dropin file
+# @param group The group to set on the dropin file
+# @param mode The mode to set on the dropin file
+# @param show_diff Whether to show the diff when updating dropin file
+# @param notify_journald Restart the journald service if the dropin file changes
+# @param journal_entry key value pairs for the [Journal] section of the dropin file
+define systemd::journald::manage_dropin (
+  Systemd::JournaldSettings      $journal_entry,
+  Systemd::Dropin                $filename                = $name,
+  Enum['present', 'absent']      $ensure                  = 'present',
+  Optional[Stdlib::Absolutepath] $path                    = undef,
+  Optional[Boolean]              $selinux_ignore_defaults = undef,
+  Optional[String[1]]            $owner                   = undef,
+  Optional[String[1]]            $group                   = undef,
+  Optional[Stdlib::Filemode]     $mode                    = undef,
+  Optional[Boolean]              $show_diff               = undef,
+  Optional[Boolean]              $notify_journald         = undef,
+) {
+  systemd::journald::dropin_file { $name:
+    ensure                  => $ensure,
+    filename                => $filename,
+    path                    => $path,
+    selinux_ignore_defaults => $selinux_ignore_defaults,
+    owner                   => $owner,
+    group                   => $group,
+    mode                    => $mode,
+    show_diff               => $show_diff,
+    notify_journald         => $notify_journald,
+    content                 => epp('systemd/journald_dropin.epp', { 'journal_entry' => $journal_entry }),
+  }
+}

--- a/spec/classes/init_spec.rb
+++ b/spec/classes/init_spec.rb
@@ -884,6 +884,7 @@ describe 'systemd' do
           it {
             is_expected.to compile.with_all_deps
             is_expected.not_to contain_service('systemd-journald')
+            is_expected.not_to contain_file('/etc/systemd/journald.conf')
           }
         end
 

--- a/spec/defines/journald/dropin_file_spec.rb
+++ b/spec/defines/journald/dropin_file_spec.rb
@@ -1,0 +1,97 @@
+# frozen_string_literal: true
+
+require 'spec_helper'
+
+describe 'systemd::journald::dropin_file' do
+  context 'supported operating systems' do
+    on_supported_os.each do |os, facts|
+      context "on #{os}" do
+        let(:facts) { facts }
+        let(:title) { 'test.conf' }
+        let(:params) do
+          {
+            content: <<~EOF,
+              [Journal]
+              Storage=persistent
+            EOF
+          }
+        end
+
+        it { is_expected.to compile.with_all_deps }
+
+        it {
+          is_expected.to contain_file('/etc/systemd/journald.conf.d')
+            .with_ensure('directory')
+            .with_recurse(false)
+            .with_purge(false)
+            .with_selinux_ignore_defaults(false)
+        }
+
+        it {
+          is_expected.to contain_file('/etc/systemd/journald.conf.d/test.conf')
+            .with_content(%r{\[Journal\]\nStorage=persistent})
+        }
+
+        it {
+          is_expected.to contain_service('systemd-journald')
+            .that_subscribes_to('File[/etc/systemd/journald.conf.d/test.conf]')
+        }
+
+        context 'with owner defined' do
+          let(:params) { super().merge(owner: 'testuser') }
+
+          it {
+            is_expected.to contain_file('/etc/systemd/journald.conf.d/test.conf')
+              .with_owner('testuser')
+          }
+        end
+
+        context 'with group defined' do
+          let(:params) { super().merge(group: 'testgroup') }
+
+          it {
+            is_expected.to contain_file('/etc/systemd/journald.conf.d/test.conf')
+              .with_group('testgroup')
+          }
+        end
+
+        context 'with mode defined' do
+          let(:params) { super().merge(mode: '0644') }
+
+          it { is_expected.to contain_file('/etc/systemd/journald.conf.d/test.conf').with_mode('0644') }
+        end
+
+        context 'with notify_journald set to false' do
+          let(:params) { super().merge(notify_journald: false) }
+
+          it {
+            is_expected.not_to contain_service('systemd-journald')
+              .that_subscribes_to('File[/etc/systemd/journald.conf.d/test.conf]')
+          }
+        end
+
+        context 'with purge_dropin_dirs set to true' do
+          let(:pre_condition) { 'class { "systemd": journald_purge_dropin_dirs => true }' }
+
+          it {
+            is_expected.to contain_file('/etc/systemd/journald.conf.d/')
+              .with_purge(true)
+              .with_recurse(true)
+          }
+        end
+
+        context 'with ensure set to absent' do
+          let(:params) { super().merge(ensure: 'absent') }
+
+          it { is_expected.to contain_file('/etc/systemd/journald.conf.d/test.conf').with_ensure('absent') }
+        end
+
+        context 'with systemd::manage_journald set to false' do
+          let(:pre_condition) { 'class { "systemd": manage_journald => false }' }
+
+          it { is_expected.to compile.and_raise_error(%r{systemd::journald::dropin_file is disabled because systemd::manage_journald is set to false}) }
+        end
+      end
+    end
+  end
+end

--- a/spec/defines/journald/manage_dropin_spec.rb
+++ b/spec/defines/journald/manage_dropin_spec.rb
@@ -1,0 +1,79 @@
+# frozen_string_literal: true
+
+require 'spec_helper'
+
+describe 'systemd::journald::manage_dropin' do
+  context 'supported operating systems' do
+    on_supported_os.each do |os, facts|
+      context "on #{os}" do
+        let(:facts) { facts }
+        let(:title) { 'test.conf' }
+        let(:params) do
+          {
+            journal_entry: {
+              'Storage' => 'persistent',
+            },
+          }
+        end
+
+        it { is_expected.to compile.with_all_deps }
+
+        it {
+          is_expected.to contain_file('/etc/systemd/journald.conf.d/test.conf')
+            .with_content(<<~EOF,
+              # This file is managed with puppet
+              [Journal]
+              Storage=persistent
+
+            EOF
+                         )
+        }
+
+        context 'with owner defined' do
+          let(:params) { super().merge(owner: 'testuser') }
+
+          it { is_expected.to contain_file('/etc/systemd/journald.conf.d/test.conf').with_owner('testuser') }
+        end
+
+        context 'with group defined' do
+          let(:params) { super().merge(group: 'testgroup') }
+
+          it { is_expected.to contain_file('/etc/systemd/journald.conf.d/test.conf').with_group('testgroup') }
+        end
+
+        context 'with mode defined' do
+          let(:params) { super().merge(mode: '0644') }
+
+          it { is_expected.to contain_file('/etc/systemd/journald.conf.d/test.conf').with_mode('0644') }
+        end
+
+        context 'with invalid journal_entry defined' do
+          let(:params) { { journal_entry: { 'foo' => 'bar' } } }
+
+          it { is_expected.to compile.and_raise_error(%r{parameter 'journal_entry' unrecognized key}) }
+        end
+
+        context 'with ensure set to absent' do
+          let(:params) { super().merge(ensure: 'absent') }
+
+          it { is_expected.to contain_file('/etc/systemd/journald.conf.d/test.conf').with_ensure('absent') }
+        end
+
+        context 'with parameter ensure set to absent' do
+          let(:params) do
+            {
+              journal_entry: {
+                'Storage' => { 'ensure' => 'absent' },
+              },
+            }
+          end
+
+          it {
+            is_expected.to contain_file('/etc/systemd/journald.conf.d/test.conf')
+              .without_content(%r{Storage=})
+          }
+        end
+      end
+    end
+  end
+end

--- a/templates/journald_dropin.epp
+++ b/templates/journald_dropin.epp
@@ -1,0 +1,9 @@
+<%- | Systemd::JournaldSettings $journal_entry | -%>
+# This file is managed with puppet
+[Journal]
+<% $journal_entry.each |$key, $value| { -%>
+<%- if $value !~ Hash { -%>
+<%= $key %>=<%= $value %>
+<% } -%>
+<% } -%>
+


### PR DESCRIPTION
<!--
Thank you for contributing to this project!

- This project has a Contributor Code of Conduct: https://voxpupuli.org/coc/
- Please check that here is no existing issue or PR that addresses your problem.
- Our vulnerabilities reporting process is at https://voxpupuli.org/security/

-->
#### Pull Request (PR) description
Debian ships a /usr/lib/systemd/journald.conf.d/syslog.conf setting ForwardToSyslog=yes which can not be overridden by the main config file, so we need to use a drop-in.
Add new defines for creating journald dropins from source or content and a manage hepler for templated gerneration. Additionally add a new toggle to disable the use of /etc/systemd/journald.conf

