### PR TITLE
Add missing [Service] directive to type alias

### DIFF
--- a/REFERENCE.md
+++ b/REFERENCE.md
@@ -6734,6 +6734,8 @@ Struct[{
     Optional['LoadCredentialEncrypted']   => Variant[String[0],Array[String[0],1]],
     Optional['SetCredential']             => Variant[String[0],Array[String[0],1]],
     Optional['SetCredentialEncrypted']    => Variant[String[0],Array[String[0],1]],
+    # Deprecated Options. Still valid systemd configuration but often hidden from man pages
+    Optional['PermissionsStartOnly']      => Boolean,
   }]
 ```
 

--- a/types/unit/service.pp
+++ b/types/unit/service.pp
@@ -173,5 +173,7 @@ type Systemd::Unit::Service = Struct[
     Optional['LoadCredentialEncrypted']   => Variant[String[0],Array[String[0],1]],
     Optional['SetCredential']             => Variant[String[0],Array[String[0],1]],
     Optional['SetCredentialEncrypted']    => Variant[String[0],Array[String[0],1]],
+    # Deprecated Options. Still valid systemd configuration but often hidden from man pages
+    Optional['PermissionsStartOnly']      => Boolean,
   }
 ]


### PR DESCRIPTION
`PermissionsStartOnly` is deprecated and removed from man pages, but is still a valid and processed option.

See https://github.com/systemd/systemd/blob/8cceaab8f5c597f207d5c86fcaa280d2e0e3a2b8/docs/TRANSIENT-SETTINGS.md#L376