### PR TITLE
Replace deprecated `Facter::Util::Resolution.exec`

### DIFF
--- a/lib/facter/systemd.rb
+++ b/lib/facter/systemd.rb
@@ -45,14 +45,14 @@ end
 Facter.add(:systemd_version) do
   confine systemd: true
   setcode do
-    Facter::Util::Resolution.exec("systemctl --version | awk '/systemd/{ print $2 }'")
+    Facter::Core::Execution.execute("systemctl --version | awk '/systemd/{ print $2 }'")
   end
 end
 
 Facter.add(:systemd_internal_services) do
   confine systemd: true
   setcode do
-    command_output = Facter::Util::Resolution.exec(
+    command_output = Facter::Core::Execution.execute(
       'systemctl list-unit-files --no-legend --no-pager "systemd-*" -t service --state=enabled,disabled,enabled-runtime,indirect,masked',
     )
     lines = command_output.lines.lazy.map { |line| line.split(%r{\s+}) }

--- a/spec/unit/facter/systemd_internal_services_spec.rb
+++ b/spec/unit/facter/systemd_internal_services_spec.rb
@@ -16,7 +16,7 @@ describe Facter.fact(:systemd_internal_services) do
       let(:facts) { { systemd: true } }
 
       it 'includes masked services in the state filter and parses service states' do
-        allow(Facter::Util::Resolution).to receive(:exec).with(
+        allow(Facter::Core::Execution).to receive(:execute).with(
           'systemctl list-unit-files --no-legend --no-pager "systemd-*" -t service --state=enabled,disabled,enabled-runtime,indirect,masked',
         ).and_return(<<~OUTPUT)
           systemd-networkd.service enabled
@@ -44,7 +44,7 @@ describe Facter.fact(:systemd_internal_services) do
       let(:facts) { { systemd: false } }
 
       it 'returns nil and does not execute systemctl' do
-        expect(Facter::Util::Resolution).not_to receive(:exec)
+        expect(Facter::Core::Execution).not_to receive(:execute)
         expect(Facter.value(:systemd_internal_services)).to be_nil
       end
     end

--- a/spec/unit/facter/systemd_version_spec.rb
+++ b/spec/unit/facter/systemd_version_spec.rb
@@ -16,7 +16,7 @@ describe Facter.fact(:systemd_version) do
       let(:facts) { { systemd: true } }
 
       it do
-        allow(Facter::Util::Resolution).to receive(:exec).with("systemctl --version | awk '/systemd/{ print $2 }'").and_return('229')
+        allow(Facter::Core::Execution).to receive(:execute).with("systemctl --version | awk '/systemd/{ print $2 }'").and_return('229')
         expect(Facter.value(:systemd_version)).to eq('229')
       end
     end
@@ -29,7 +29,7 @@ describe Facter.fact(:systemd_version) do
       let(:facts) { { systemd: false } }
 
       it do
-        expect(Facter::Util::Resolution).not_to receive(:exec).with("systemctl --version | awk '/systemd/{ print $2 }'")
+        expect(Facter::Core::Execution).not_to receive(:execute).with("systemctl --version | awk '/systemd/{ print $2 }'")
         expect(Facter.value(:systemd_version)).to be_nil
       end
     end


### PR DESCRIPTION
#### Pull Request (PR) description

Replace `Facter::Util::Resolution` with `Facter::Core::Execution`.

#### This Pull Request (PR) fixes the following issues

```
Warning: Facter: Facter::Util::Resolution.exec is deprecated and will be removed in a future major version. Use Facter::Core::Execution.execute instead.
```